### PR TITLE
Add minimal repository draft files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*.tmp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Repository guidance
+
+## Scope
+
+This repository stores reusable agent skills and a small amount of supporting documentation and tooling.
+
+## Rules
+
+- Keep all repository text and skill artifacts in English.
+- Store each skill at `skills/<skill-name>/SKILL.md`.
+- Keep each skill narrow, explicit, and operational.
+- Avoid registry-specific assumptions in skill content.
+- Prefer project-local installation over global installation.
+- Update `skills/README.md` when adding, removing, or renaming a skill.
+- Do not add build systems, package managers, or generated files unless there is a clear repository-level need.
+
+## Editing policy
+
+When drafting or revising files in this repository:
+
+- prefer compact wording over long narrative explanation
+- keep examples minimal
+- avoid placeholders that obscure the intended workflow

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # skills
-Agent skills
+
+This repository is the source of truth for a small set of agent skills.
+
+The default distribution model is conservative:
+
+- keep each skill under version control in this repository
+- avoid public registries and auto-install workflows by default
+- copy only the required skills into a project workspace when needed
+
+This layout is intended to work with agents that discover skills from local folders, including:
+
+- Claude Code: `.claude/skills/`
+- Codex: `.agents/skills/`
+
+## Repository layout
+
+```text
+skills/
+  <skill-name>/
+    SKILL.md
+scripts/
+  install-skill.sh
+```
+
+## Installation model
+
+The installer script copies one skill from this repository into a target workspace.
+It does not depend on a remote marketplace or registry.
+
+Example:
+
+```sh
+./scripts/install-skill.sh my-skill both /path/to/workspace
+```
+
+## Notes
+
+- Keep repository files and skill artifacts in English.
+- Keep skills narrow, explicit, and easy for agents to apply.
+- Prefer project-local installation unless there is a clear reason to install globally.

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/install-skill.sh <skill-name> [claude|codex|both] [workspace-root]
+
+Examples:
+  ./scripts/install-skill.sh transfer-prompt
+  ./scripts/install-skill.sh transfer-prompt claude .
+  ./scripts/install-skill.sh transfer-prompt both /path/to/workspace
+EOF
+}
+
+if [ "${1:-}" = "" ] || [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+SKILL_NAME="$1"
+TARGET_KIND="${2:-both}"
+WORKSPACE_ROOT="${3:-.}"
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+SOURCE_DIR="$REPO_ROOT/skills/$SKILL_NAME"
+
+if [ ! -d "$SOURCE_DIR" ]; then
+  echo "Skill not found: $SKILL_NAME" >&2
+  exit 1
+fi
+
+copy_skill() {
+  target_root="$1"
+  target_dir="$target_root/$SKILL_NAME"
+  mkdir -p "$target_root"
+  rm -rf "$target_dir"
+  cp -R "$SOURCE_DIR" "$target_dir"
+  echo "Installed $SKILL_NAME -> $target_dir"
+}
+
+case "$TARGET_KIND" in
+  claude)
+    copy_skill "$WORKSPACE_ROOT/.claude/skills"
+    ;;
+  codex)
+    copy_skill "$WORKSPACE_ROOT/.agents/skills"
+    ;;
+  both)
+    copy_skill "$WORKSPACE_ROOT/.claude/skills"
+    copy_skill "$WORKSPACE_ROOT/.agents/skills"
+    ;;
+  *)
+    echo "Invalid target: $TARGET_KIND" >&2
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -22,6 +22,13 @@ SKILL_NAME="$1"
 TARGET_KIND="${2:-both}"
 WORKSPACE_ROOT="${3:-.}"
 
+case "$SKILL_NAME" in
+  .*|*/*|*\\*|*".."*|*[^A-Za-z0-9._-]*)
+    echo "Invalid skill name: $SKILL_NAME" >&2
+    exit 1
+    ;;
+esac
+
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 SOURCE_DIR="$REPO_ROOT/skills/$SKILL_NAME"

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,18 @@
+# skills directory
+
+Each skill should live in its own directory:
+
+```text
+skills/<skill-name>/SKILL.md
+```
+
+Guidelines:
+
+- one directory per skill
+- stable, descriptive skill names
+- concise documentation
+- no generated files
+
+Current status:
+
+- no skills have been added yet


### PR DESCRIPTION
## Summary

Add a minimal repository skeleton for managing local agent skills conservatively.

## Changes

- expand the top-level README
- add a minimal .gitignore
- add AGENTS.md with repository-specific guidance
- add a small installer script for copying a skill into a workspace
- add a README for the skills directory

## Intent

This keeps the repository lightweight and aligned with a project-local installation model rather than a registry-first workflow.