### PR TITLE
Add Copilot support and Gemini compatibility install mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Supported targets:
 - `codex`: install to `.agents/skills/`
 - `copilot`: install to `.github/skills/`
 - `gemini`: compatibility mode via `.gemini/skills/` plus `.gemini/GEMINI.md`
-- `both`: install to Claude Code and Codex locations
 - `all`: install to Claude Code, Codex, Copilot, and Gemini compatibility locations
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -8,10 +8,16 @@ The default distribution model is conservative:
 - avoid public registries and auto-install workflows by default
 - copy only the required skills into a project workspace when needed
 
-This layout is intended to work with agents that discover skills from local folders, including:
+## Tool compatibility
 
-- Claude Code: `.claude/skills/`
-- Codex: `.agents/skills/`
+This repository targets multiple coding agents, but each tool discovers reusable guidance differently:
+
+- Claude Code: project-local skills in `.claude/skills/`
+- Codex: project-local skills in `.agents/skills/`
+- GitHub Copilot CLI: project-local skills in `.github/skills/` or `.claude/skills/`
+- Gemini CLI: project-local context from `GEMINI.md`; official reusable packaging is based on Gemini extensions
+
+For Gemini CLI, this repository provides a compatibility install mode that copies a skill into `.gemini/skills/` and imports its `SKILL.md` from `.gemini/GEMINI.md`.
 
 ## Repository layout
 
@@ -28,11 +34,32 @@ scripts/
 The installer script copies one skill from this repository into a target workspace.
 It does not depend on a remote marketplace or registry.
 
-Example:
+Supported targets:
+
+- `claude`: install to `.claude/skills/`
+- `codex`: install to `.agents/skills/`
+- `copilot`: install to `.github/skills/`
+- `gemini`: compatibility mode via `.gemini/skills/` plus `.gemini/GEMINI.md`
+- `both`: install to Claude Code and Codex locations
+- `all`: install to Claude Code, Codex, Copilot, and Gemini compatibility locations
+
+Examples:
 
 ```sh
-./scripts/install-skill.sh my-skill both /path/to/workspace
+./scripts/install-skill.sh my-skill codex /path/to/workspace
+./scripts/install-skill.sh my-skill copilot /path/to/workspace
+./scripts/install-skill.sh my-skill gemini /path/to/workspace
+./scripts/install-skill.sh my-skill all /path/to/workspace
 ```
+
+## Project instruction files
+
+These are separate from skills, but they affect project-local behaviour:
+
+- GitHub Copilot supports `AGENTS.md`, `GEMINI.md`, and `.github/copilot-instructions.md`
+- Gemini CLI loads hierarchical `GEMINI.md` files and can be configured to accept other context filenames
+
+The installer in this repository currently copies skills only. It does not generate repository-wide instruction files such as `AGENTS.md` or `.github/copilot-instructions.md`.
 
 ## Notes
 

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -4,7 +4,7 @@ set -eu
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/install-skill.sh <skill-name> [claude|codex|copilot|gemini|both|all] [workspace-root]
+  ./scripts/install-skill.sh <skill-name> [claude|codex|copilot|gemini|all] [workspace-root]
 
 Examples:
   ./scripts/install-skill.sh transfer-prompt
@@ -84,10 +84,6 @@ case "$TARGET_KIND" in
     ;;
   gemini)
     install_gemini_compat
-    ;;
-  both)
-    copy_skill "$WORKSPACE_ROOT/.claude/skills"
-    copy_skill "$WORKSPACE_ROOT/.agents/skills"
     ;;
   all)
     copy_skill "$WORKSPACE_ROOT/.claude/skills"

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -4,12 +4,14 @@ set -eu
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/install-skill.sh <skill-name> [claude|codex|both] [workspace-root]
+  ./scripts/install-skill.sh <skill-name> [claude|codex|copilot|gemini|both|all] [workspace-root]
 
 Examples:
   ./scripts/install-skill.sh transfer-prompt
-  ./scripts/install-skill.sh transfer-prompt claude .
-  ./scripts/install-skill.sh transfer-prompt both /path/to/workspace
+  ./scripts/install-skill.sh transfer-prompt codex .
+  ./scripts/install-skill.sh transfer-prompt copilot /path/to/workspace
+  ./scripts/install-skill.sh transfer-prompt gemini /path/to/workspace
+  ./scripts/install-skill.sh transfer-prompt all /path/to/workspace
 EOF
 }
 
@@ -19,7 +21,7 @@ if [ "${1:-}" = "" ] || [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
 fi
 
 SKILL_NAME="$1"
-TARGET_KIND="${2:-both}"
+TARGET_KIND="${2:-codex}"
 WORKSPACE_ROOT="${3:-.}"
 
 case "$SKILL_NAME" in
@@ -47,6 +49,29 @@ copy_skill() {
   echo "Installed $SKILL_NAME -> $target_dir"
 }
 
+install_gemini_compat() {
+  gemini_root="$WORKSPACE_ROOT/.gemini"
+  gemini_md="$gemini_root/GEMINI.md"
+  import_line="@./skills/$SKILL_NAME/SKILL.md"
+
+  copy_skill "$gemini_root/skills"
+  mkdir -p "$gemini_root"
+
+  if [ ! -f "$gemini_md" ]; then
+    printf '# Gemini project context\n\n%s\n' "$import_line" > "$gemini_md"
+    echo "Created $gemini_md"
+    return 0
+  fi
+
+  if grep -Fqx "$import_line" "$gemini_md"; then
+    echo "Gemini import already present in $gemini_md"
+    return 0
+  fi
+
+  printf '\n%s\n' "$import_line" >> "$gemini_md"
+  echo "Updated $gemini_md"
+}
+
 case "$TARGET_KIND" in
   claude)
     copy_skill "$WORKSPACE_ROOT/.claude/skills"
@@ -54,9 +79,21 @@ case "$TARGET_KIND" in
   codex)
     copy_skill "$WORKSPACE_ROOT/.agents/skills"
     ;;
+  copilot)
+    copy_skill "$WORKSPACE_ROOT/.github/skills"
+    ;;
+  gemini)
+    install_gemini_compat
+    ;;
   both)
     copy_skill "$WORKSPACE_ROOT/.claude/skills"
     copy_skill "$WORKSPACE_ROOT/.agents/skills"
+    ;;
+  all)
+    copy_skill "$WORKSPACE_ROOT/.claude/skills"
+    copy_skill "$WORKSPACE_ROOT/.agents/skills"
+    copy_skill "$WORKSPACE_ROOT/.github/skills"
+    install_gemini_compat
     ;;
   *)
     echo "Invalid target: $TARGET_KIND" >&2


### PR DESCRIPTION
## Summary

Document and support GitHub Copilot CLI and Gemini CLI in the local installation workflow.

## Changes

- add a native `copilot` install target that copies skills into `.github/skills`
- add a `gemini` compatibility install target that copies a skill into `.gemini/skills` and imports it from `.gemini/GEMINI.md`
- update the README to distinguish native skill support from instruction-file support
- keep `both` for Claude Code + Codex and `all` for all supported targets

## Notes

This PR is intentionally conservative:

- Copilot uses a documented native project skill location
- Gemini uses documented `GEMINI.md` project context as a compatibility layer, rather than assuming stable native `SKILL.md` directory support in public docs
- no registry or marketplace workflow is introduced
