### PR TITLE
Add staged planning skills

### DIFF
--- a/skills/lightweight-spec/SKILL.md
+++ b/skills/lightweight-spec/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: lightweight-spec
+description: Produce a compact implementation brief for medium-complexity tasks that are too large for immediate coding but do not justify heavy planning review.
+---
+
+# Lightweight Spec
+
+Produce a compact planning document for medium-complexity implementation work.
+
+This skill covers the middle zone between:
+
+- doing the work immediately
+- sending planning artifacts to implementation-readiness review
+
+The goal is to create just enough structure to reduce ambiguity and rework without imposing heavy process overhead.
+
+## When to use
+
+Use this skill when:
+
+- the task is not trivial
+- some decisions, risks, or boundaries should be made explicit
+- implementation spans multiple files or one bounded subsystem
+- a coding agent would benefit from a concise execution brief
+- full review of detailed planning artifacts would be excessive
+
+Do not use this skill for:
+
+- tiny local edits that can be executed immediately
+- large, high-risk, or highly ambiguous changes that should go through implementation-readiness review
+
+## Deliverable
+
+Produce a single compact document with these sections.
+
+# Task
+A short statement of what is being changed.
+
+# Goal
+The intended operational outcome.
+
+# Scope
+## In
+What is included.
+
+## Out
+What is excluded.
+
+# Constraints
+Known requirements, assumptions, conventions, or non-negotiable conditions.
+
+# Risks
+The main failure modes, ambiguities, or edge cases.
+
+# Implementation outline
+A short sequence of concrete implementation steps.
+
+# Done criteria
+Observable conditions that determine completion.
+
+## Style requirements
+
+- Be compact.
+- Prefer concrete statements over discussion.
+- Avoid speculative design unless necessary.
+- Optimise for immediate executability.
+- Write for a coding agent with no hidden context.
+
+## Procedure
+
+1. Restate the task in concrete terms.
+2. Identify the minimum necessary scope.
+3. Extract explicit constraints and assumptions.
+4. List only the most relevant risks.
+5. Produce a short implementation outline.
+6. Define done criteria that can be checked objectively.
+
+## Output template
+
+```md
+# Task
+
+# Goal
+
+# Scope
+## In
+## Out
+
+# Constraints
+
+# Risks
+
+# Implementation outline
+
+# Done criteria
+```
+
+## Important constraints
+
+- Do not expand into a full design document unless clearly necessary.
+- Do not create artificial sections beyond the template.
+- Keep the document lean enough that writing it costs less than one failed implementation attempt.

--- a/skills/planning-triage/SKILL.md
+++ b/skills/planning-triage/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: planning-triage
+description: Decide whether a development task should be done immediately, handled with a lightweight spec, or sent to implementation-readiness review.
+---
+
+# Planning Triage
+
+Classify an incoming development task into one of three routes:
+
+- `DO_IT_NOW`
+- `LIGHTWEIGHT_SPEC`
+- `IMPLEMENTATION_READINESS_REVIEW`
+
+The purpose of this skill is to keep planning overhead proportional to task difficulty.
+Use the lightest route that still protects execution quality.
+
+## When to use
+
+Use this skill when:
+
+- the user asks which planning depth is appropriate
+- the task may or may not justify structured planning
+- the implementation scope is not yet clear
+- the user refers to staged planning, triage, routing, or planning depth selection
+- it is unclear whether immediate execution would be efficient or reckless
+
+Do not use this skill when the user has already chosen a specific planning mode and that choice is clearly appropriate.
+
+## Evaluation criteria
+
+Assess the task on these axes.
+
+### 1. Ambiguity
+
+How unclear are the requirements, scope, constraints, or completion conditions?
+
+### 2. Blast radius
+
+How many files, modules, interfaces, workflows, or behaviours are likely to change?
+
+### 3. Reversibility
+
+How easy would it be to undo a bad implementation choice?
+
+### 4. Interruption risk
+
+How likely is a coding agent to pause for clarification during execution?
+
+### 5. Review value
+
+How much would upfront planning reduce rework, drift, or hallucinated decisions?
+
+## Routing rules
+
+### Route: DO_IT_NOW
+
+Choose this when most of the following hold:
+
+- requirements are already concrete
+- impact is local
+- the change is easily reversible
+- acceptance criteria are obvious
+- planning overhead would exceed likely rework cost
+
+Typical examples:
+
+- wording edits
+- renaming
+- tiny bug fixes
+- narrow mechanical changes
+- local refactors with obvious boundaries
+
+### Route: LIGHTWEIGHT_SPEC
+
+Choose this when:
+
+- the task is not trivial, but still bounded
+- a short execution brief would reduce drift
+- a few constraints, risks, or edge cases should be written down
+- full review of heavy planning artifacts would be disproportionate
+
+Typical examples:
+
+- medium feature additions
+- non-trivial refactors within one subsystem
+- changes spanning several files with limited design uncertainty
+- work that needs one compact implementation brief before coding
+
+### Route: IMPLEMENTATION_READINESS_REVIEW
+
+Choose this when one or more of the following hold:
+
+- requirements are materially ambiguous
+- the change affects architecture, interfaces, invariants, or migration
+- multiple design choices must be resolved or tightened before coding
+- the cost of a wrong implementation is high
+- a coding agent would likely stall, guess, or re-research
+- execution depends on hardened specs, plans, or task breakdowns
+
+Typical examples:
+
+- cross-cutting refactors
+- architecture changes
+- risky migrations
+- tasks intended for autonomous coding agents where interruption must be minimised
+
+## Output format
+
+Return:
+
+1. the selected route
+2. a short justification
+3. the main factors that drove the decision
+4. the immediate next action
+
+Use this structure:
+
+```text
+Route: <DO_IT_NOW | LIGHTWEIGHT_SPEC | IMPLEMENTATION_READINESS_REVIEW>
+
+Why:
+- ...
+- ...
+
+Key factors:
+- Ambiguity: low|medium|high
+- Blast radius: low|medium|high
+- Reversibility: high|medium|low
+- Review value: low|medium|high
+
+Next action:
+- ...
+```
+
+## Important constraints
+
+- Prefer the lightest adequate route.
+- Do not escalate merely because the task is technical.
+- Do not under-plan when ambiguity would predictably cause clarification loops or rework.
+- Optimise for total execution efficiency rather than procedural formality.


### PR DESCRIPTION
## Summary
- add `skills/planning-triage/SKILL.md`
- add `skills/lightweight-spec/SKILL.md`
- define a staged planning flow around `do it now / lightweight spec / implementation-readiness review`

## Notes
- `planning-triage` acts as the entry skill and routes work to the lightest adequate path
- `lightweight-spec` covers the middle layer for bounded but non-trivial tasks
- the existing `implementation-readiness-review` skill remains the heavy review layer
- I attempted to update `skills/README.md` in the same branch, but the current connector path for updating an existing file rejected the operation; I left the PR focused on the new skills rather than fabricate a risky workaround
