### PR TITLE
Refactor install script for native skills and batch support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ Thumbs.db
 *.swp
 *.swo
 *.tmp
+
+# Local agent installs
+.claude/
+.gemini/
+.agents/
+.github/skills/

--- a/README.md
+++ b/README.md
@@ -54,13 +54,11 @@ This repository targets multiple coding agents, but each tool discovers reusable
 - Claude Code: project-local skills in `.claude/skills/`
 - Codex: project-local skills in `.agents/skills/`
 - GitHub Copilot CLI: project-local skills in `.github/skills/` or `.claude/skills/`
-- Gemini CLI: project-local context from `GEMINI.md`; official reusable packaging is based on Gemini extensions
-
-For Gemini CLI, this repository provides a compatibility install mode that copies a skill into `.gemini/skills/` and imports its `SKILL.md` from `.gemini/GEMINI.md`.
+- Gemini CLI: project-local skills in `.gemini/skills/`
 
 ## Installation model
 
-The installer script copies one skill from this repository into a target workspace.
+The installer script copies skills from this repository into a target workspace.
 It does not depend on a remote marketplace or registry.
 
 Supported targets:
@@ -68,13 +66,14 @@ Supported targets:
 - `claude`: install to `.claude/skills/`
 - `codex`: install to `.agents/skills/`
 - `copilot`: install to `.github/skills/`
-- `gemini`: compatibility mode via `.gemini/skills/` plus `.gemini/GEMINI.md`
-- `all`: install to Claude Code, Codex, Copilot, and Gemini compatibility locations
+- `gemini`: install to `.gemini/skills/`
+- `all`: install to all supported agent locations
 
 Examples:
 
 ```sh
-./scripts/install-skill.sh triage codex /path/to/workspace
+./scripts/install-skill.sh all all
+./scripts/install-skill.sh triage codex .
 ./scripts/install-skill.sh lite-spec copilot /path/to/workspace
 ./scripts/install-skill.sh metaplan gemini /path/to/workspace
 ./scripts/install-skill.sh handoff-prompt all /path/to/workspace

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -4,10 +4,10 @@ set -eu
 usage() {
   cat <<'EOF'
 Usage:
-  ./scripts/install-skill.sh <skill-name> [claude|codex|copilot|gemini|all] [workspace-root]
+  ./scripts/install-skill.sh <skill-name|all> [claude|codex|copilot|gemini|all] [workspace-root]
 
 Examples:
-  ./scripts/install-skill.sh handoff-prompt
+  ./scripts/install-skill.sh all all
   ./scripts/install-skill.sh triage codex .
   ./scripts/install-skill.sh lite-spec copilot /path/to/workspace
   ./scripts/install-skill.sh metaplan gemini /path/to/workspace
@@ -20,80 +20,82 @@ if [ "${1:-}" = "" ] || [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
   exit 0
 fi
 
-SKILL_NAME="$1"
-TARGET_KIND="${2:-codex}"
+SKILL_NAME_INPUT="$1"
+TARGET_KIND_INPUT="${2:-codex}"
 WORKSPACE_ROOT="${3:-.}"
-
-case "$SKILL_NAME" in
-  .*|*/*|*\\*|*".."*|*[^A-Za-z0-9._-]*)
-    echo "Invalid skill name: $SKILL_NAME" >&2
-    exit 1
-    ;;
-esac
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
-SOURCE_DIR="$REPO_ROOT/skills/$SKILL_NAME"
-
-if [ ! -d "$SOURCE_DIR" ]; then
-  echo "Skill not found: $SKILL_NAME" >&2
-  exit 1
-fi
+SKILLS_DIR="$REPO_ROOT/skills"
 
 copy_skill() {
-  target_root="$1"
-  target_dir="$target_root/$SKILL_NAME"
-  mkdir -p "$target_root"
+  skill_name="$1"
+  target_base_dir="$2"
+  source_dir="$SKILLS_DIR/$skill_name"
+  target_dir="$target_base_dir/$skill_name"
+
+  if [ ! -d "$source_dir" ]; then
+    echo "Skill not found: $skill_name" >&2
+    exit 1
+  fi
+
+  mkdir -p "$target_base_dir"
   rm -rf "$target_dir"
-  cp -R "$SOURCE_DIR" "$target_dir"
-  echo "Installed $SKILL_NAME -> $target_dir"
+  cp -R "$source_dir" "$target_dir"
+  echo "Installed $skill_name -> $target_dir"
 }
 
-install_gemini_compat() {
-  gemini_root="$WORKSPACE_ROOT/.gemini"
-  gemini_md="$gemini_root/GEMINI.md"
-  import_line="@./skills/$SKILL_NAME/SKILL.md"
+install_to_kind() {
+  skill_name="$1"
+  kind="$2"
 
-  copy_skill "$gemini_root/skills"
-  mkdir -p "$gemini_root"
-
-  if [ ! -f "$gemini_md" ]; then
-    printf '# Gemini project context\n\n%s\n' "$import_line" > "$gemini_md"
-    echo "Created $gemini_md"
-    return 0
-  fi
-
-  if grep -Fqx "$import_line" "$gemini_md"; then
-    echo "Gemini import already present in $gemini_md"
-    return 0
-  fi
-
-  printf '\n%s\n' "$import_line" >> "$gemini_md"
-  echo "Updated $gemini_md"
+  case "$kind" in
+    claude)
+      copy_skill "$skill_name" "$WORKSPACE_ROOT/.claude/skills"
+      ;;
+    codex)
+      copy_skill "$skill_name" "$WORKSPACE_ROOT/.agents/skills"
+      ;;
+    copilot)
+      copy_skill "$skill_name" "$WORKSPACE_ROOT/.github/skills"
+      ;;
+    gemini)
+      copy_skill "$skill_name" "$WORKSPACE_ROOT/.gemini/skills"
+      ;;
+    all)
+      copy_skill "$skill_name" "$WORKSPACE_ROOT/.claude/skills"
+      copy_skill "$skill_name" "$WORKSPACE_ROOT/.agents/skills"
+      copy_skill "$skill_name" "$WORKSPACE_ROOT/.github/skills"
+      copy_skill "$skill_name" "$WORKSPACE_ROOT/.gemini/skills"
+      ;;
+    *)
+      echo "Invalid target: $kind" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
 }
 
-case "$TARGET_KIND" in
-  claude)
-    copy_skill "$WORKSPACE_ROOT/.claude/skills"
-    ;;
-  codex)
-    copy_skill "$WORKSPACE_ROOT/.agents/skills"
-    ;;
-  copilot)
-    copy_skill "$WORKSPACE_ROOT/.github/skills"
-    ;;
-  gemini)
-    install_gemini_compat
-    ;;
+# Validate skill name input (prevent path traversal)
+case "$SKILL_NAME_INPUT" in
   all)
-    copy_skill "$WORKSPACE_ROOT/.claude/skills"
-    copy_skill "$WORKSPACE_ROOT/.agents/skills"
-    copy_skill "$WORKSPACE_ROOT/.github/skills"
-    install_gemini_compat
     ;;
-  *)
-    echo "Invalid target: $TARGET_KIND" >&2
-    usage >&2
+  .*|*/*|*\\*|*".."*|*[^A-Za-z0-9._-]*)
+    echo "Invalid skill name: $SKILL_NAME_INPUT" >&2
     exit 1
     ;;
 esac
+
+if [ "$SKILL_NAME_INPUT" = "all" ]; then
+  # Iterate over all directories in skills/
+  for skill_path in "$SKILLS_DIR"/*; do
+    if [ -d "$skill_path" ]; then
+      skill_name=$(basename "$skill_path")
+      # Skip README.md if it's a directory (unlikely, but safe)
+      if [ "$skill_name" = "README.md" ]; then continue; fi
+      install_to_kind "$skill_name" "$TARGET_KIND_INPUT"
+    fi
+  done
+else
+  install_to_kind "$SKILL_NAME_INPUT" "$TARGET_KIND_INPUT"
+fi

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -28,6 +28,11 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 SKILLS_DIR="$REPO_ROOT/skills"
 
+if [ ! -d "$SKILLS_DIR" ]; then
+  echo "Skills directory not found: $SKILLS_DIR" >&2
+  exit 1
+fi
+
 copy_skill() {
   skill_name="$1"
   target_base_dir="$2"
@@ -36,6 +41,11 @@ copy_skill() {
 
   if [ ! -d "$source_dir" ]; then
     echo "Skill not found: $skill_name" >&2
+    exit 1
+  fi
+
+  if [ ! -f "$source_dir/SKILL.md" ]; then
+    echo "Invalid skill '$skill_name': missing $source_dir/SKILL.md" >&2
     exit 1
   fi
 
@@ -87,15 +97,23 @@ case "$SKILL_NAME_INPUT" in
 esac
 
 if [ "$SKILL_NAME_INPUT" = "all" ]; then
+  count=0
   # Iterate over all directories in skills/
   for skill_path in "$SKILLS_DIR"/*; do
     if [ -d "$skill_path" ]; then
       skill_name=$(basename "$skill_path")
       # Skip README.md if it's a directory (unlikely, but safe)
       if [ "$skill_name" = "README.md" ]; then continue; fi
+      
       install_to_kind "$skill_name" "$TARGET_KIND_INPUT"
+      count=$((count + 1))
     fi
   done
+  
+  if [ "$count" -eq 0 ]; then
+    echo "No skills found in $SKILLS_DIR" >&2
+    exit 1
+  fi
 else
   install_to_kind "$SKILL_NAME_INPUT" "$TARGET_KIND_INPUT"
 fi

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -101,17 +101,17 @@ if [ "$SKILL_NAME_INPUT" = "all" ]; then
   # Iterate over all directories in skills/
   for skill_path in "$SKILLS_DIR"/*; do
     if [ -d "$skill_path" ]; then
+      # Skip non-skill directories (must contain SKILL.md)
+      if [ ! -f "$skill_path/SKILL.md" ]; then continue; fi
+
       skill_name=$(basename "$skill_path")
-      # Skip README.md if it's a directory (unlikely, but safe)
-      if [ "$skill_name" = "README.md" ]; then continue; fi
-      
       install_to_kind "$skill_name" "$TARGET_KIND_INPUT"
       count=$((count + 1))
     fi
   done
   
   if [ "$count" -eq 0 ]; then
-    echo "No skills found in $SKILLS_DIR" >&2
+    echo "No valid skills found in $SKILLS_DIR" >&2
     exit 1
   fi
 else


### PR DESCRIPTION
This PR introduces two main changes:
1. **Batch Installation**: Users can now use `all` as the skill name to install all available skills at once (e.g., `./scripts/install-skill.sh all all`).
2. **Native Gemini Skills**: Removed the workaround that injected skills into `GEMINI.md` via `@` imports. Gemini CLI now uses native skill discovery in `.gemini/skills/`, matching the behavior of Claude Code and other agents.

These changes improve context efficiency for Gemini users and simplify the setup process for all supported agents.