### PR TITLE
fix: unify Gemini skill path to .agents/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This repository targets multiple coding agents, but each tool discovers reusable
 - Claude Code: project-local skills in `.claude/skills/`
 - Codex: project-local skills in `.agents/skills/`
 - GitHub Copilot CLI: project-local skills in `.github/skills/` or `.claude/skills/`
-- Gemini CLI: project-local skills in `.gemini/skills/`
+- Gemini CLI: project-local skills in `.agents/skills/`
 
 ## Installation model
 
@@ -66,7 +66,7 @@ Supported targets:
 - `claude`: install to `.claude/skills/`
 - `codex`: install to `.agents/skills/`
 - `copilot`: install to `.github/skills/`
-- `gemini`: install to `.gemini/skills/`
+- `gemini`: install to `.agents/skills/`
 - `all`: install to all supported agent locations
 
 Examples:

--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -70,13 +70,12 @@ install_to_kind() {
       copy_skill "$skill_name" "$WORKSPACE_ROOT/.github/skills"
       ;;
     gemini)
-      copy_skill "$skill_name" "$WORKSPACE_ROOT/.gemini/skills"
+      copy_skill "$skill_name" "$WORKSPACE_ROOT/.agents/skills"
       ;;
     all)
       copy_skill "$skill_name" "$WORKSPACE_ROOT/.claude/skills"
       copy_skill "$skill_name" "$WORKSPACE_ROOT/.agents/skills"
       copy_skill "$skill_name" "$WORKSPACE_ROOT/.github/skills"
-      copy_skill "$skill_name" "$WORKSPACE_ROOT/.gemini/skills"
       ;;
     *)
       echo "Invalid target: $kind" >&2


### PR DESCRIPTION
Gemini CLI also searches in .agents/skills and prefers it over .gemini/skills. This PR unifies the installation path to .agents/skills to avoid redundancy and potential conflicts when both directories exist.