### PR TITLE
Add external-skill-review skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Each skill must live at `skills/<skill-name>/SKILL.md`.
 
 - `git-prune-worktrees`: safely prune stale refs, clean merged worktrees, merged local branches, and stale worktree metadata
 
+### External skills
+
+- `external-skill-review`: review a candidate external skill against the repo policy, record approved entries in a project-local catalog, and recommend install commands
+
 ## Naming guidance
 
 Prefer short, command-friendly names.

--- a/skills/README.md
+++ b/skills/README.md
@@ -22,3 +22,4 @@ Current skills:
 - marimo-reactive-review
 - growing-agents-md
 - git-prune-worktrees
+- external-skill-review

--- a/skills/external-skill-review/SKILL.md
+++ b/skills/external-skill-review/SKILL.md
@@ -37,7 +37,9 @@ Read `.agents/approved-external-skills.json` in the target workspace using the b
 python3 skills/external-skill-review/scripts/catalog.py get <repo> <skill_path>
 ```
 
-If a matching approved entry exists, skip to step 8 and reuse the stored provenance.
+If a matching approved entry exists **with the same `pinned_ref`**, skip to step 8 and reuse the stored provenance.
+
+If the entry exists but the `pinned_ref` differs, treat it as a new review event and continue from step 2. Each upstream update requires a fresh review.
 
 ### 2. Validate specificity
 

--- a/skills/external-skill-review/SKILL.md
+++ b/skills/external-skill-review/SKILL.md
@@ -34,12 +34,12 @@ Work through these steps in order. Stop at the first blocking condition.
 Read `.agents/approved-external-skills.json` in the target workspace using the bundled script:
 
 ```sh
-python3 skills/external-skill-review/scripts/catalog.py get <repo> <skill_path>
+python3 skills/external-skill-review/scripts/catalog.py get <repo> <skill_path> <pinned_ref>
 ```
 
-If a matching approved entry exists **with the same `pinned_ref`**, skip to step 8 and reuse the stored provenance.
+If the script prints an entry, an exact match on `(repo, skill_path, pinned_ref)` with `review_status: approved` exists — skip to step 8 and reuse the stored provenance.
 
-If the entry exists but the `pinned_ref` differs, treat it as a new review event and continue from step 2. Each upstream update requires a fresh review.
+If the script prints nothing, proceed from step 2. This covers: no catalog file, no matching entry, a matching entry with a different `pinned_ref`, and a matching entry that is not approved. Each upstream update requires a fresh review.
 
 ### 2. Validate specificity
 
@@ -145,8 +145,8 @@ Example entry:
 Use the bundled script to read and write the catalog reliably:
 
 ```sh
-# Look up an entry
-python3 skills/external-skill-review/scripts/catalog.py get owner/repo skills/example
+# Look up an entry (repo, skill_path, pinned_ref must all match)
+python3 skills/external-skill-review/scripts/catalog.py get owner/repo skills/example abc1234
 
 # Add or update an entry (pass JSON string)
 python3 skills/external-skill-review/scripts/catalog.py add '{"repo":"owner/repo","skill_path":"skills/example",...}'

--- a/skills/external-skill-review/SKILL.md
+++ b/skills/external-skill-review/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: external-skill-review
+description: Review a candidate external skill against the repo policy, record approved entries in a project-local catalog, and recommend Agent Skills CLI install commands when approved.
+---
+
+# External Skill Review
+
+Use this skill when the user wants to adopt an external skill, reuse a prior approval, or check whether a candidate is already cataloged.
+
+Do not use this skill to review skills that already live in this repository.
+
+This skill does not install anything. Final installation and trust decisions remain the user's responsibility.
+
+Governing policy: `docs/external-skills.md`.
+
+## Inputs
+
+Gather the following before proceeding. Ask the user for any that are missing.
+
+- `repo` — upstream repository in `owner/repo` form
+- `skill_path` — path or name of the skill within that repository
+- `pinned_ref` — commit SHA (preferred), or a branch or tag with a documented reason
+- `targets` — agent targets (e.g. `claude`, `codex`, `copilot`, `gemini`)
+- `license` — SPDX identifier or plain description; state "unknown" if not yet checked
+- `notes` — any relevant review notes already available
+- `catalog_entry` — optional; pass if the user wants to reuse a prior approval
+
+## Decision flow
+
+Work through these steps in order. Stop at the first blocking condition.
+
+### 1. Check the catalog
+
+Read `.agents/approved-external-skills.json` in the target workspace using the bundled script:
+
+```sh
+python3 skills/external-skill-review/scripts/catalog.py get <repo> <skill_path>
+```
+
+If a matching approved entry exists, skip to step 8 and reuse the stored provenance.
+
+### 2. Validate specificity
+
+If `repo` or `skill_path` is missing or too vague to identify a unique upstream source, return `needs manual review` and ask for more detail.
+
+### 3. Check pinning
+
+If `pinned_ref` is not a commit SHA:
+- If it is a branch or tag, the user must provide a documented reason before proceeding. Treat as a provisional exception, not the default.
+- If no ref is provided at all, return `not approved`. Do not approve an unpinned install.
+
+### 4. Check license
+
+If the license is missing, unknown, ambiguous, or incompatible with the intended use, return `not approved`.
+
+### 5. Check higher-risk content
+
+Identify whether the skill includes any of the following:
+- shell, Python, or Node.js helpers that modify the workspace
+- prompts or helpers that execute commands on behalf of the user
+- references to remote resources that may change independently of the pinned ref
+- compiled binaries, obfuscated or minified code
+- installers, update hooks, or bootstrap scripts that pull in additional code
+
+If disallowed content is present (compiled binaries, obfuscated code, auto-downloading installers), return `not approved`.
+
+If higher-risk but reviewable content is present, flag it explicitly and require the user to confirm they have reviewed it before returning `approved`.
+
+### 6. Apply policy
+
+Apply the full approval rules from `docs/external-skills.md`. All of the following must be true for `approved`:
+
+- upstream repository, skill path, and pinned commit SHA are identified
+- repository owner or maintainers are known and trusted for the intended use
+- skill content is readable and reviewable
+- license is clear enough to allow the intended use
+- any scripts or executable helpers are small enough to review directly and acceptable for project-local use
+
+### 7. Classify
+
+Return one of:
+- `approved` — all checks pass
+- `not approved` — at least one hard blocker (no SHA, bad license, disallowed content)
+- `needs manual review` — inputs are incomplete or a check cannot be resolved automatically
+
+### 8. Emit output
+
+See **Required output** below.
+
+If `approved` or reusing an approved catalog entry:
+- describe the catalog entry to write
+- provide Agent Skills CLI command examples
+
+If `not approved` or `needs manual review`:
+- explain what is missing or what blocks approval
+- do not emit install commands
+
+## Required output
+
+Return all five items in this order:
+
+1. **Result** — `approved`, `not approved`, or `needs manual review`
+2. **Rationale** — short explanation tied to specific policy checks
+3. **Provenance fields** — the fields the user should preserve or update in the catalog:
+   - `repo`
+   - `skill_path`
+   - `pinned_ref`
+   - `targets`
+   - `license`
+   - `review_status`
+   - `reviewer`
+   - `review_date`
+   - `notes`
+4. **Next steps** — what the user should do after this review
+5. **Install commands** — only when result is `approved` or reusing an approved catalog entry
+
+Example install commands (replace placeholders):
+
+```sh
+npx agent-skills-cli install owner/repo#COMMIT_SHA --skill skill-path -a claude,codex
+```
+
+## Catalog model
+
+The catalog lives at `.agents/approved-external-skills.json` in the target workspace. It is a JSON array of provenance entries.
+
+Example entry:
+
+```json
+{
+  "repo": "owner/repo",
+  "skill_path": "skills/example",
+  "pinned_ref": "abc1234",
+  "targets": ["claude", "codex"],
+  "license": "MIT",
+  "review_status": "approved",
+  "reviewer": "your-name",
+  "review_date": "2026-04-17",
+  "notes": ""
+}
+```
+
+Use the bundled script to read and write the catalog reliably:
+
+```sh
+# Look up an entry
+python3 skills/external-skill-review/scripts/catalog.py get owner/repo skills/example
+
+# Add or update an entry (pass JSON string)
+python3 skills/external-skill-review/scripts/catalog.py add '{"repo":"owner/repo","skill_path":"skills/example",...}'
+```
+
+The home directory is not the source of truth. Keep the catalog project-local.
+
+## Constraints
+
+- Never auto-install. This skill reviews, catalogs, and recommends only.
+- Do not emit install commands unless the result is `approved` or the entry being reused is `approved`.
+- Do not approve when any required field is unknown or incomplete.
+- Treat branch or tag refs as documented exceptions, not the default.
+- Treat each upstream update as a new review event with a new commit SHA.
+- Do not override `docs/external-skills.md`.

--- a/skills/external-skill-review/SKILL.md
+++ b/skills/external-skill-review/SKILL.md
@@ -119,7 +119,8 @@ Return all five items in this order:
 Example install commands (replace placeholders):
 
 ```sh
-npx agent-skills-cli install owner/repo#COMMIT_SHA --skill skill-path -a claude,codex
+npx agent-skills-cli add owner/repo@skill-name
+npx agent-skills-cli install owner/repo#COMMIT_SHA -a claude,codex
 ```
 
 ## Catalog model

--- a/skills/external-skill-review/scripts/catalog.py
+++ b/skills/external-skill-review/scripts/catalog.py
@@ -42,6 +42,7 @@ def cmd_get(repo: str, skill_path: str) -> None:
         print(json.dumps(entry, indent=2))
         return
 
+
 def cmd_add(raw: str) -> None:
     new_entry = json.loads(raw)
     repo = new_entry.get("repo")

--- a/skills/external-skill-review/scripts/catalog.py
+++ b/skills/external-skill-review/scripts/catalog.py
@@ -5,8 +5,9 @@ Narrow helper for reading and writing the approved external skills catalog.
 Catalog location: .agents/approved-external-skills.json (relative to cwd).
 
 Usage:
-  python3 catalog.py get <repo> <skill_path>
+  python3 catalog.py get <repo> <skill_path> <pinned_ref>
       Print the matching approved entry as JSON, or nothing if not found.
+      All three fields must match. A different pinned_ref returns nothing.
 
   python3 catalog.py add <json-entry>
       Append or update an entry in the catalog.
@@ -31,13 +32,15 @@ def save(entries: list[dict]) -> None:
     CATALOG_PATH.write_text(json.dumps(entries, indent=2) + "\n")
 
 
-def cmd_get(repo: str, skill_path: str) -> None:
+def cmd_get(repo: str, skill_path: str, pinned_ref: str) -> None:
     for entry in load():
         if entry.get("review_status") != "approved":
             continue
         if entry.get("repo") != repo:
             continue
         if entry.get("skill_path") != skill_path:
+            continue
+        if entry.get("pinned_ref") != pinned_ref:
             continue
         print(json.dumps(entry, indent=2))
         return
@@ -67,10 +70,10 @@ def main() -> None:
 
     command = sys.argv[1]
     if command == "get":
-        if len(sys.argv) != 4:
-            print("usage: catalog.py get <repo> <skill_path>", file=sys.stderr)
+        if len(sys.argv) != 5:
+            print("usage: catalog.py get <repo> <skill_path> <pinned_ref>", file=sys.stderr)
             sys.exit(1)
-        cmd_get(sys.argv[2], sys.argv[3])
+        cmd_get(sys.argv[2], sys.argv[3], sys.argv[4])
     elif command == "add":
         if len(sys.argv) != 3:
             print("usage: catalog.py add <json-entry>", file=sys.stderr)

--- a/skills/external-skill-review/scripts/catalog.py
+++ b/skills/external-skill-review/scripts/catalog.py
@@ -11,12 +11,13 @@ Usage:
 
   python3 catalog.py add <json-entry>
       Append or update an entry in the catalog.
-      Matches on (repo, skill_path). Overwrites an existing entry if found.
+      Matches on (repo, skill_path, pinned_ref). Adds a new entry if not found.
 """
 
 import json
 import pathlib
 import sys
+import tempfile
 
 CATALOG_PATH = pathlib.Path(".agents/approved-external-skills.json")
 
@@ -24,12 +25,37 @@ CATALOG_PATH = pathlib.Path(".agents/approved-external-skills.json")
 def load() -> list[dict]:
     if not CATALOG_PATH.exists():
         return []
-    return json.loads(CATALOG_PATH.read_text())
+    try:
+        entries = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
+    except OSError as exc:
+        print(f"error: unable to read catalog {CATALOG_PATH}: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as exc:
+        print(f"error: catalog {CATALOG_PATH} contains invalid JSON: {exc}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(entries, list):
+        print(f"error: catalog {CATALOG_PATH} must contain a JSON list", file=sys.stderr)
+        sys.exit(1)
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            print(
+                f"error: catalog {CATALOG_PATH} entry at index {i} must be a JSON object",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    return entries
 
 
 def save(entries: list[dict]) -> None:
     CATALOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    CATALOG_PATH.write_text(json.dumps(entries, indent=2) + "\n")
+    text = json.dumps(entries, indent=2) + "\n"
+    tmp = pathlib.Path(tempfile.mktemp(dir=CATALOG_PATH.parent, prefix=".catalog-tmp-"))
+    try:
+        tmp.write_text(text, encoding="utf-8")
+        tmp.replace(CATALOG_PATH)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
 
 
 def cmd_get(repo: str, skill_path: str, pinned_ref: str) -> None:
@@ -50,12 +76,17 @@ def cmd_add(raw: str) -> None:
     new_entry = json.loads(raw)
     repo = new_entry.get("repo")
     skill_path = new_entry.get("skill_path")
-    if not repo or not skill_path:
-        print("error: entry must include 'repo' and 'skill_path'", file=sys.stderr)
+    pinned_ref = new_entry.get("pinned_ref")
+    if not repo or not skill_path or not pinned_ref:
+        print("error: entry must include 'repo', 'skill_path', and 'pinned_ref'", file=sys.stderr)
         sys.exit(1)
     entries = load()
     for i, entry in enumerate(entries):
-        if entry.get("repo") == repo and entry.get("skill_path") == skill_path:
+        if (
+            entry.get("repo") == repo
+            and entry.get("skill_path") == skill_path
+            and entry.get("pinned_ref") == pinned_ref
+        ):
             entries[i] = new_entry
             save(entries)
             return

--- a/skills/external-skill-review/scripts/catalog.py
+++ b/skills/external-skill-review/scripts/catalog.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Narrow helper for reading and writing the approved external skills catalog.
+
+Catalog location: .agents/approved-external-skills.json (relative to cwd).
+
+Usage:
+  python3 catalog.py get <repo> <skill_path>
+      Print the matching approved entry as JSON, or nothing if not found.
+
+  python3 catalog.py add <json-entry>
+      Append or update an entry in the catalog.
+      Matches on (repo, skill_path). Overwrites an existing entry if found.
+"""
+
+import json
+import pathlib
+import sys
+
+CATALOG_PATH = pathlib.Path(".agents/approved-external-skills.json")
+
+
+def load() -> list[dict]:
+    if not CATALOG_PATH.exists():
+        return []
+    return json.loads(CATALOG_PATH.read_text())
+
+
+def save(entries: list[dict]) -> None:
+    CATALOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CATALOG_PATH.write_text(json.dumps(entries, indent=2) + "\n")
+
+
+def cmd_get(repo: str, skill_path: str) -> None:
+    for entry in load():
+        if entry.get("repo") == repo and entry.get("skill_path") == skill_path:
+            print(json.dumps(entry, indent=2))
+            return
+
+
+def cmd_add(raw: str) -> None:
+    new_entry = json.loads(raw)
+    repo = new_entry.get("repo")
+    skill_path = new_entry.get("skill_path")
+    if not repo or not skill_path:
+        print("error: entry must include 'repo' and 'skill_path'", file=sys.stderr)
+        sys.exit(1)
+    entries = load()
+    for i, entry in enumerate(entries):
+        if entry.get("repo") == repo and entry.get("skill_path") == skill_path:
+            entries[i] = new_entry
+            save(entries)
+            return
+    entries.append(new_entry)
+    save(entries)
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print(__doc__.strip())
+        return
+
+    command = sys.argv[1]
+    if command == "get":
+        if len(sys.argv) != 4:
+            print("usage: catalog.py get <repo> <skill_path>", file=sys.stderr)
+            sys.exit(1)
+        cmd_get(sys.argv[2], sys.argv[3])
+    elif command == "add":
+        if len(sys.argv) != 3:
+            print("usage: catalog.py add <json-entry>", file=sys.stderr)
+            sys.exit(1)
+        cmd_add(sys.argv[2])
+    else:
+        print(f"unknown command: {command}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/external-skill-review/scripts/catalog.py
+++ b/skills/external-skill-review/scripts/catalog.py
@@ -33,10 +33,14 @@ def save(entries: list[dict]) -> None:
 
 def cmd_get(repo: str, skill_path: str) -> None:
     for entry in load():
-        if entry.get("repo") == repo and entry.get("skill_path") == skill_path:
-            print(json.dumps(entry, indent=2))
-            return
-
+        if entry.get("review_status") != "approved":
+            continue
+        if entry.get("repo") != repo:
+            continue
+        if entry.get("skill_path") != skill_path:
+            continue
+        print(json.dumps(entry, indent=2))
+        return
 
 def cmd_add(raw: str) -> None:
     new_entry = json.loads(raw)


### PR DESCRIPTION
## Summary

- Adds `skills/external-skill-review/SKILL.md` with the full decision flow from issue #18: catalog lookup, pinning check, license check, higher-risk content check, policy application, and result classification
- Adds `skills/external-skill-review/scripts/catalog.py` — narrow helper for reading/writing `.agents/approved-external-skills.json`
- Updates `README.md` and `skills/README.md` to list the new skill

## Key design decisions

- Install commands are only emitted when result is `approved` or reusing an approved catalog entry
- No auto-install logic anywhere in the new files
- Branch/tag refs treated as explicit documented exceptions, not the default
- Catalog is project-local (`.agents/approved-external-skills.json`), not home-directory state
- Governing policy reference: `docs/external-skills.md`

## Test plan

- [ ] Read `skills/external-skill-review/SKILL.md` and verify all 8 decision-flow steps are present
- [ ] Run `python3 skills/external-skill-review/scripts/catalog.py --help` — should print usage
- [ ] Confirm `README.md` and `skills/README.md` list `external-skill-review`
- [ ] Confirm no auto-install logic in any new file

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)