### PR TITLE
fix: replace invalid manual fallback for external-skill install

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,28 @@ Examples:
 ./scripts/install-skill.sh triage codex /path/to/workspace --force
 ```
 
+## APM installation
+
+This repository is compatible with [APM (Agent Package Manager)](https://microsoft.github.io/apm).
+
+Install individual skills via subpath:
+
+```sh
+apm install t-uda/skills/skills/triage
+apm install t-uda/skills/skills/metaplan
+apm install t-uda/skills/skills/lite-spec
+```
+
+Install with pinned commit:
+
+```sh
+apm install t-uda/skills/skills/triage#abc1234
+```
+
+APM automatically deploys skills to detected target directories (`.github/skills/`, `.claude/skills/`, `.agents/skills/`, etc.).
+
+The manual installer script remains available for environments where APM is not installed.
+
 ## Project instruction files
 
 These are separate from skills, but they affect project-local behaviour:

--- a/docs/external-skills.md
+++ b/docs/external-skills.md
@@ -14,16 +14,21 @@ It does not vendor those skills into this repository, and it does not extend `sc
 
 ## Normative tool
 
-Use Agent Skills CLI as the normative example tool for this policy.
+Use APM (Agent Package Manager) as the preferred tool for this policy.
 
 Example commands:
 
 ```sh
-npx agent-skills-cli add owner/repo@skill-name -a claude,codex,copilot
-npx agent-skills-cli install owner/repo#COMMIT_SHA -a codex
+# Install with pinned commit (preferred)
+apm install owner/repo/path/to/skill#COMMIT_SHA
+
+# Install from repo root if skill is at root
+apm install owner/repo#COMMIT_SHA
 ```
 
-If a project uses another tool, it should meet the same pinning, provenance, license, and review requirements described here.
+APM automatically deploys to detected target directories (`.github/skills/`, `.claude/skills/`, `.agents/skills/`, etc.).
+
+If APM is not available, use manual installation with the same pinning, provenance, license, and review requirements described here.
 
 ## Approval rules
 

--- a/skills/external-skill-review/SKILL.md
+++ b/skills/external-skill-review/SKILL.md
@@ -131,10 +131,10 @@ apm install owner/repo#COMMIT_SHA
 **Fallback (manual, APM unavailable):**
 
 ```sh
-# Clone the upstream repo and copy or link the skill into the target directory
-git clone --depth 1 https://github.com/owner/repo /tmp/ext-skill-repo
+# Clone and checkout the reviewed commit SHA, then copy into the target directory
+git clone https://github.com/owner/repo /tmp/ext-skill-repo
+git -C /tmp/ext-skill-repo checkout COMMIT_SHA
 cp -r /tmp/ext-skill-repo/path/to/skill .agents/skills/skill-name
-# or symlink: ln -s /tmp/ext-skill-repo/path/to/skill .agents/skills/skill-name
 ```
 
 APM automatically deploys to detected target directories (`.github/skills/`, `.claude/skills/`, `.agents/skills/`, etc.).

--- a/skills/external-skill-review/SKILL.md
+++ b/skills/external-skill-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: external-skill-review
-description: Review a candidate external skill against the repo policy, record approved entries in a project-local catalog, and recommend Agent Skills CLI install commands when approved.
+description: Review a candidate external skill against the repo policy, record approved entries in a project-local catalog, and recommend APM install commands when approved.
 ---
 
 # External Skill Review
@@ -118,10 +118,26 @@ Return all five items in this order:
 
 Example install commands (replace placeholders):
 
+**Preferred (APM):**
+
 ```sh
-npx agent-skills-cli add owner/repo@skill-name
-npx agent-skills-cli install owner/repo#COMMIT_SHA -a claude,codex
+# Install with pinned commit
+apm install owner/repo/path/to/skill#COMMIT_SHA
+
+# Or install from root if skill is at repo root
+apm install owner/repo#COMMIT_SHA
 ```
+
+**Fallback (manual, APM unavailable):**
+
+```sh
+# Clone the upstream repo and copy or link the skill into the target directory
+git clone --depth 1 https://github.com/owner/repo /tmp/ext-skill-repo
+cp -r /tmp/ext-skill-repo/path/to/skill .agents/skills/skill-name
+# or symlink: ln -s /tmp/ext-skill-repo/path/to/skill .agents/skills/skill-name
+```
+
+APM automatically deploys to detected target directories (`.github/skills/`, `.claude/skills/`, `.agents/skills/`, etc.).
 
 ## Catalog model
 


### PR DESCRIPTION
Migrates external-skill installation guidance from `agent-skills-cli` to APM, and adds a correct manual fallback for environments where APM is unavailable.

**Changes:**
- `docs/external-skills.md`: replace `npx agent-skills-cli` examples with `apm install` (pinned commit form); update fallback note
- `skills/external-skill-review/SKILL.md`: update frontmatter description; replace install examples with APM-first + `git clone`/`checkout`/`cp` manual fallback
- `README.md`: add APM installation section

Closes #25.