### PR TITLE
APM phase-1: commit apm.yml and document consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ APM automatically deploys skills to detected target directories (`.github/skills
 
 The manual installer script remains available for environments where APM is not installed.
 
+### Install-first, compile-minimal
+
+This repository favours native install over compiled instruction files:
+
+- `apm install` is the preferred path. Skills land directly in each tool's native directory.
+- `apm compile` output (`AGENTS.md`, `CLAUDE.md`) is treated as a compatibility layer only.
+- Compiled artifacts in this repo stay compact: durable policy, minimal guardrails, and pointers. Procedures live in skill files, not in compiled documents.
+
+### Current APM scope
+
+Phase 1 covers skills only. Prompts, agents, instructions, hooks, and MCP are not distributed from this repository yet. See `docs/apm-consumption.md` for supported primitives, target-directory mapping per tool, and subpath install patterns.
+
 ## Project instruction files
 
 These are separate from skills, but they affect project-local behaviour:

--- a/apm.yml
+++ b/apm.yml
@@ -1,0 +1,5 @@
+name: t-uda-skills
+version: 0.1.0
+description: Reusable agent skills for development workflows
+author: Tomoki UDA
+license: MIT

--- a/docs/apm-consumption.md
+++ b/docs/apm-consumption.md
@@ -70,9 +70,12 @@ workspace. Observed behaviour with APM CLI 0.8.12:
 | Tool                    | Skill destination   | Detection trigger |
 | ----------------------- | ------------------- | ----------------- |
 | Claude Code             | `.claude/skills/`   | `.claude/` present |
-| GitHub Copilot / VSCode | `.github/skills/`   | `.github/` present, or created as fallback |
+| GitHub Copilot / VSCode | `.github/skills/`   | `.github/` present |
 | Cursor                  | `.cursor/skills/`   | `.cursor/` present |
 | OpenCode                | `.opencode/skills/` | `.opencode/` present |
+
+If no native target directory is present in the consuming workspace, APM
+creates `.github/` and deploys skills under `.github/skills/` as a fallback.
 
 Notes:
 
@@ -90,10 +93,16 @@ At least one subpath install is verified end-to-end before releases that
 change APM-facing layout or metadata. Record of the last validation is kept
 in this document when it is run.
 
-Last validated: 2026-04-21 against APM CLI 0.8.12. `apm install
-t-uda/skills/skills/triage` and a pinned-commit variant both resolved the
-skill and deployed into `.claude/skills/` and (when `.github/` was present)
-`.github/skills/`.
+Last validated: 2026-04-21 against APM CLI 0.8.12.
+
+- `apm install t-uda/skills/skills/triage` in a workspace with `.claude/`
+  and `.github/` present: deployed to `.claude/skills/triage/` and
+  `.github/skills/triage/`.
+- `apm install t-uda/skills/skills/metaplan#<sha>` (pinned commit) in a
+  workspace with only `.claude/` present: deployed to `.claude/skills/metaplan/`.
+- `apm install t-uda/skills/skills/triage` in a bare workspace with no
+  native directories: APM created `.github/` and deployed to
+  `.github/skills/triage/`.
 
 ## Follow-ups
 

--- a/docs/apm-consumption.md
+++ b/docs/apm-consumption.md
@@ -1,0 +1,104 @@
+# APM consumption
+
+This document describes how to consume this repository via APM
+([Agent Package Manager](https://microsoft.github.io/apm)).
+
+## Scope
+
+Phase 1 ships **skills only**. The following APM primitive types are not
+distributed from this repository yet:
+
+- prompts
+- agents
+- instructions
+- hooks
+- MCP server configs
+- plugin bundles
+
+Each is tracked as a separate follow-up and will be evaluated before adoption.
+
+## Policy
+
+- `apm install` is the preferred consumption path for tools that support it.
+- Compiled outputs (`AGENTS.md`, `CLAUDE.md`) produced by `apm compile` are a
+  compatibility layer, not the primary delivery. Compiled artifacts in this
+  repository stay compact and procedural content remains in skill files.
+- The manual installer (`scripts/install-skill.sh`) remains supported for
+  environments without APM.
+
+## Repository layout
+
+Skills live at `skills/<skill-name>/SKILL.md`. This is a monorepo layout; APM
+consumes each skill by subpath rather than as a single bundled package.
+
+There is no `.apm/` directory. It will be introduced only when a non-skill
+primitive is added to this repository.
+
+## Install patterns
+
+### Single skill by subpath
+
+```sh
+apm install t-uda/skills/skills/triage
+apm install t-uda/skills/skills/metaplan
+apm install t-uda/skills/skills/lite-spec
+```
+
+### Pinned commit
+
+```sh
+apm install t-uda/skills/skills/triage#<commit-sha>
+```
+
+Pin to a commit SHA for reproducible installs. Branch or tag refs are allowed
+as explicit exceptions only.
+
+### Declared in `apm.yml`
+
+```yaml
+dependencies:
+  apm:
+    - t-uda/skills/skills/triage
+    - t-uda/skills/skills/metaplan#<commit-sha>
+```
+
+## Target directory mapping
+
+APM deploys skills to the native directories it detects in the consuming
+workspace. Observed behaviour with APM CLI 0.8.12:
+
+| Tool                    | Skill destination   | Detection trigger |
+| ----------------------- | ------------------- | ----------------- |
+| Claude Code             | `.claude/skills/`   | `.claude/` present |
+| GitHub Copilot / VSCode | `.github/skills/`   | `.github/` present, or created as fallback |
+| Cursor                  | `.cursor/skills/`   | `.cursor/` present |
+| OpenCode                | `.opencode/skills/` | `.opencode/` present |
+
+Notes:
+
+- The exact set of auto-detected targets may evolve. Verify against the APM
+  version in use.
+- In validation with APM 0.8.12, a bare `.agents/` directory did not trigger
+  a Codex skill deploy. If Codex support is required, confirm the current
+  APM detection rules before relying on it.
+- Non-skill primitive targets (`.claude/commands/`, `.github/prompts/`,
+  `.github/agents/`, etc.) are not exercised by this repository in phase 1.
+
+## Validation
+
+At least one subpath install is verified end-to-end before releases that
+change APM-facing layout or metadata. Record of the last validation is kept
+in this document when it is run.
+
+Last validated: 2026-04-21 against APM CLI 0.8.12. `apm install
+t-uda/skills/skills/triage` and a pinned-commit variant both resolved the
+skill and deployed into `.claude/skills/` and (when `.github/` was present)
+`.github/skills/`.
+
+## Follow-ups
+
+- Evaluate whether to migrate skills under `.apm/skills/` when a non-skill
+  primitive is first added.
+- Evaluate adoption of prompts, agents, instructions, or hooks as separate
+  tracked issues.
+- Revisit repository name if scope broadens beyond skills.


### PR DESCRIPTION
## Summary
- Commits the root `apm.yml` so APM can treat this repo as a skill provider.
- Adds an install-first / compile-minimal policy section to `README.md`.
- Introduces `docs/apm-consumption.md`: primitives in scope, subpath install patterns, target-directory mapping per tool, validation record.

Phase 1 is intentionally conservative and skill-only. The existing manual installer (`scripts/install-skill.sh`) remains supported.

## Validation
Verified against APM CLI 0.8.12 in a scratch workspace:

- \`apm install t-uda/skills/skills/triage\` — resolved the skill and deployed to \`.claude/skills/\` and \`.github/skills/\`.
- \`apm install t-uda/skills/skills/metaplan#<sha>\` — pinned-commit install worked and deployed to \`.claude/skills/\` only (no \`.github/\` in that workspace).
- A bare \`.agents/\` directory did not trigger a Codex deploy with this APM version; noted in the doc so readers do not rely on it.

## Follow-ups (not in this PR)
- Decide whether to migrate skills under \`.apm/skills/\` when a non-skill primitive is first added.
- Evaluate prompts / agents / instructions / hooks as separate tracked issues.
- Revisit repository name if scope broadens beyond skills.

Refs #24.

## Test plan
- [ ] Review README additions render correctly on GitHub.
- [ ] Review \`docs/apm-consumption.md\` for accuracy and tone.
- [ ] Sanity-check \`apm.yml\` fields (name / version / description / author / license).
- [ ] Optional: rerun \`apm install t-uda/skills/skills/<name>\` from a clean workspace to reconfirm.