### PR TITLE
Add devcontainer-cli skill (issue #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Each skill must live at `skills/<skill-name>/SKILL.md`.
 
 - `external-skill-review`: review a candidate external skill against the repo policy, record approved entries in a project-local catalog, and recommend install commands
 
+### Dev containers
+
+- `devcontainer-cli`: review, validate, and troubleshoot Dev Container setup with explicit CLI-first guidance
+
 ## Naming guidance
 
 Prefer short, command-friendly names.

--- a/skills/README.md
+++ b/skills/README.md
@@ -26,3 +26,4 @@ Current skills:
 - sot-integrity
 - light-orchestration
 - deslop-history
+- devcontainer-cli

--- a/skills/devcontainer-cli/SKILL.md
+++ b/skills/devcontainer-cli/SKILL.md
@@ -19,6 +19,7 @@ Use this skill when a task involves `.devcontainer/`, `devcontainer.json`, Dev C
 
 - Prefer the official Dev Container specification and CLI behaviour over editor-specific assumptions.
 - Inspect `.devcontainer/`, Dockerfile, Compose files, and referenced scripts before editing.
+- Treat commands that start the container or run lifecycle hooks as execution steps, not routine inspection.
 - Choose the simplest viable topology:
   - `image` for simple reuse
   - `build` for project-specific tooling
@@ -32,11 +33,16 @@ Use this skill when a task involves `.devcontainer/`, `devcontainer.json`, Dev C
 
 Use the CLI as the primary validation path:
 
-- `devcontainer read-configuration --workspace-folder <repo>`
-- `devcontainer build --workspace-folder <repo>`
-- `devcontainer up --workspace-folder <repo>`
-- `devcontainer exec --workspace-folder <repo> <cmd>`
-- `devcontainer run-user-commands --workspace-folder <repo>`
+- Read-only inspection:
+  - `devcontainer read-configuration --workspace-folder <repo>`
+- Build validation:
+  - `devcontainer build --workspace-folder <repo>`
+  - This can pull images or run Docker build steps, but it does not run repo lifecycle hooks by itself.
+- Approval-required execution:
+  - `devcontainer up --workspace-folder <repo>`
+  - `devcontainer exec --workspace-folder <repo> <cmd>`
+  - `devcontainer run-user-commands --workspace-folder <repo>`
+  - Use these only after explicit approval, because they start the target container and may run repo-defined lifecycle hooks or project commands.
 
 Do not assume a setup is correct until it is CLI-verifiable.
 

--- a/skills/devcontainer-cli/SKILL.md
+++ b/skills/devcontainer-cli/SKILL.md
@@ -18,25 +18,28 @@ Use this skill when a task involves `.devcontainer/`, `devcontainer.json`, Dev C
 ## Core rules
 
 - Prefer the official Dev Container specification and CLI behaviour over editor-specific assumptions.
+- Treat committed `.devcontainer/*`, referenced Docker/Compose files, and lifecycle scripts as the current implementation; treat the official specification and CLI behaviour as the correctness authority when editor defaults disagree.
 - Inspect `.devcontainer/`, Dockerfile, Compose files, and referenced scripts before editing.
+- Edit `.devcontainer/*`, referenced Docker/Compose files, and lifecycle scripts only when needed for the task.
 - Treat commands that start the container or run lifecycle hooks as execution steps, not routine inspection.
 - Choose the simplest viable topology:
   - `image` for simple reuse
   - `build` for project-specific tooling
   - `dockerComposeFile` for multi-service environments
-- Prefer Features or Templates over ad-hoc bootstrap when practical.
-- Place lifecycle commands in the correct phase, and avoid heavy repeated work in startup hooks.
+- Prefer a maintained Feature or Template when it already provides the required tool or runtime; use ad-hoc bootstrap only when the setup is repo-specific or no suitable reusable option exists.
+- Put one-time setup in `onCreateCommand`, `updateContentCommand`, or `postCreateCommand`; keep `postStartCommand` and `postAttachCommand` lightweight, idempotent, and fast.
 - Treat `remoteUser` and `containerUser` carefully, especially for Linux bind-mount permissions.
-- Optimise for reproducibility across laptop, VM, server, and CI.
+- Flag host-only assumptions such as absolute host paths, host package managers, or UID/GID expectations that will not survive across laptop, VM, server, or CI.
 
 ## CLI workflow
 
-Use the CLI as the primary validation path:
+Use CLI validation when the task requires runtime verification and the environment has Dev Container CLI, Docker/Compose access, and approval for execution steps.
 
-- Read-only inspection:
+- Static inspection:
   - `devcontainer read-configuration --workspace-folder <repo>`
-- Build validation:
+- Optional build validation:
   - `devcontainer build --workspace-folder <repo>`
+  - Use this when image or build correctness matters and Docker-heavy execution is in scope.
   - This can pull images or run Docker build steps, but it does not run repo lifecycle hooks by itself.
 - Approval-required execution:
   - `devcontainer up --workspace-folder <repo>`
@@ -44,7 +47,7 @@ Use the CLI as the primary validation path:
   - `devcontainer run-user-commands --workspace-folder <repo>`
   - Use these only after explicit approval, because they start the target container and may run repo-defined lifecycle hooks or project commands.
 
-Do not assume a setup is correct until it is CLI-verifiable.
+If runtime validation cannot run, complete a static review and state exactly which validation steps remain unverified.
 
 ## What to check
 
@@ -76,7 +79,8 @@ Provide:
 
 - proposed config changes
 - brief rationale
-- exact CLI validation commands
+- validation status: static review only, build-validated, or runtime-validated
+- exact CLI validation commands run, skipped, or still required
 - remaining assumptions or risks
 
 ## References

--- a/skills/devcontainer-cli/SKILL.md
+++ b/skills/devcontainer-cli/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: devcontainer-cli
+description: Use this skill when working with Dev Containers, devcontainer.json, or Dev Container CLI for setup, review, validation, or troubleshooting.
+---
+
+# Dev Container CLI
+
+Use this skill when a task involves `.devcontainer/`, `devcontainer.json`, Dev Container Features/Templates, or Dev Container CLI commands.
+
+## Goals
+
+- review existing Dev Container setup
+- create or revise `devcontainer.json`
+- choose among image / Dockerfile / Compose setups
+- validate with Dev Container CLI
+- troubleshoot common Dev Container-specific failures
+
+## Core rules
+
+- Prefer the official Dev Container specification and CLI behaviour over editor-specific assumptions.
+- Inspect `.devcontainer/`, Dockerfile, Compose files, and referenced scripts before editing.
+- Choose the simplest viable topology:
+  - `image` for simple reuse
+  - `build` for project-specific tooling
+  - `dockerComposeFile` for multi-service environments
+- Prefer Features or Templates over ad-hoc bootstrap when practical.
+- Place lifecycle commands in the correct phase, and avoid heavy repeated work in startup hooks.
+- Treat `remoteUser` and `containerUser` carefully, especially for Linux bind-mount permissions.
+- Optimise for reproducibility across laptop, VM, server, and CI.
+
+## CLI workflow
+
+Use the CLI as the primary validation path:
+
+- `devcontainer read-configuration --workspace-folder <repo>`
+- `devcontainer build --workspace-folder <repo>`
+- `devcontainer up --workspace-folder <repo>`
+- `devcontainer exec --workspace-folder <repo> <cmd>`
+- `devcontainer run-user-commands --workspace-folder <repo>`
+
+Do not assume a setup is correct until it is CLI-verifiable.
+
+## What to check
+
+When reviewing or authoring a Dev Container, check:
+
+- topology choice is justified
+- lifecycle commands are placed correctly
+- ports and mounts are minimal and explicit
+- user and permission settings are coherent
+- secrets are not baked into committed files
+- host-specific assumptions are avoided
+- the setup can be reused or prebuilt when beneficial
+
+## Troubleshooting checklist
+
+Check in roughly this order:
+
+1. config or path errors
+2. image / build / compose mismatch
+3. lifecycle hook misuse
+4. user or UID/GID mismatch
+5. mount or workspace issues
+6. service readiness or port issues
+7. env or secret handling mistakes
+
+## Output expectations
+
+Provide:
+
+- proposed config changes
+- brief rationale
+- exact CLI validation commands
+- remaining assumptions or risks
+
+## References
+
+- Development Containers specification: https://containers.dev/
+- Dev Container CLI: https://github.com/devcontainers/cli

--- a/skills/devcontainer-cli/SKILL.md
+++ b/skills/devcontainer-cli/SKILL.md
@@ -18,9 +18,9 @@ Use this skill when a task involves `.devcontainer/`, `devcontainer.json`, Dev C
 ## Core rules
 
 - Prefer the official Dev Container specification and CLI behaviour over editor-specific assumptions.
-- Treat committed `.devcontainer/*`, referenced Docker/Compose files, and lifecycle scripts as the current implementation; treat the official specification and CLI behaviour as the correctness authority when editor defaults disagree.
+- Treat committed `.devcontainer/` contents, referenced Docker/Compose files, and lifecycle scripts as the current implementation; treat the official specification and CLI behaviour as the correctness authority when editor defaults disagree.
 - Inspect `.devcontainer/`, Dockerfile, Compose files, and referenced scripts before editing.
-- Edit `.devcontainer/*`, referenced Docker/Compose files, and lifecycle scripts only when needed for the task.
+- Edit `.devcontainer/` contents, referenced Docker/Compose files, and lifecycle scripts only when needed for the task.
 - Treat commands that start the container or run lifecycle hooks as execution steps, not routine inspection.
 - Choose the simplest viable topology:
   - `image` for simple reuse
@@ -37,11 +37,11 @@ Use CLI validation when the task requires runtime verification and the environme
 
 - Static inspection:
   - `devcontainer read-configuration --workspace-folder <repo>`
-- Optional build validation:
+- Approval-required build validation:
   - `devcontainer build --workspace-folder <repo>`
-  - Use this when image or build correctness matters and Docker-heavy execution is in scope.
-  - This can pull images or run Docker build steps, but it does not run repo lifecycle hooks by itself.
-- Approval-required execution:
+  - Use this only after explicit approval, when image or build correctness matters and Docker-heavy execution is in scope.
+  - This can pull images and run Docker build steps or Feature installs, even though it does not run repo lifecycle hooks by itself.
+- Approval-required runtime execution:
   - `devcontainer up --workspace-folder <repo>`
   - `devcontainer exec --workspace-folder <repo> <cmd>`
   - `devcontainer run-user-commands --workspace-folder <repo>`


### PR DESCRIPTION
Add a focused `devcontainer-cli` skill for issue #34 and tighten it based on review and metaplan feedback.

## What changed

- add the `devcontainer-cli` skill for Dev Container setup, validation, and troubleshooting
- add the skill to `skills/README.md` and the root `README.md`
- gate `devcontainer up`, `devcontainer exec`, and `devcontainer run-user-commands` behind explicit approval
- clarify source of truth, edit scope, lifecycle placement, validation prerequisites, and the static-review fallback

## Why

The initial skill covered the basic workflow, but review surfaced a safety gap around commands that can start containers and run lifecycle hooks. A follow-up metaplan pass also found execution-readiness gaps for autonomous agents when runtime validation cannot run.

## Impact

Agents now have a safer and more explicit path for reviewing or editing Dev Container setups without assuming runtime validation is always available.

## Validation

- inspected the updated markdown locally
- `git diff --check`
- no automated tests; doc-only change

Closes #34
