### PR TITLE
Implement growing-agents-md script workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Each skill must live at `skills/<skill-name>/SKILL.md`.
 
 ### Repository guidance
 
-- `growing-agents-md`: create or refine a compact `AGENTS.md` without letting it bloat
+- `growing-agents-md`: seed, lint, or update a compact canonical `AGENTS.md` with deterministic guardrails
 
 ### Git maintenance
 

--- a/skills/growing-agents-md/SKILL.md
+++ b/skills/growing-agents-md/SKILL.md
@@ -1,167 +1,57 @@
 ---
 name: growing-agents-md
-description: Create a compact AGENTS.md when missing, or refine an existing AGENTS.md so it stays short, current, and useful for implementation agents. Use this when the user explicitly asks for a growing, compact AGENTS.md or wants to create or maintain AGENTS.md without letting it bloat.
+description: Seed, lint, or update a compact canonical AGENTS.md with deterministic guardrails. Use this when AGENTS.md is missing, stale, structurally degraded, or when durable repo guidance changed.
 ---
 
 # Growing AGENTS.md
 
-Maintain a compact, high-signal `AGENTS.md` for the current repository.
+Use this skill to keep `AGENTS.md` canonical, compact, and durable.
 
-This skill has exactly two jobs:
+Use it when:
 
-1. **If `AGENTS.md` does not exist:** create a minimal, high-quality one.
-2. **If `AGENTS.md` already exists:** refine it so it remains compact, current, and implementation-useful.
+- `AGENTS.md` is missing
+- `AGENTS.md` fails structural lint
+- the current task changes durable commands, architecture, or workflow rules
+- the file became generic, bloated, or stale enough to prune
 
-The goal is **not** to accumulate notes.  
-The goal is to keep `AGENTS.md` **short, project-specific, and operationally valuable**.
+The bundled script is the source of truth for scaffold shape, guard comments, placeholder rules, section rendering, and the counted-line budget:
 
-## Core policy
+```sh
+python3 skills/growing-agents-md/scripts/growing_agents_md.py <command>
+```
 
-Treat `AGENTS.md` as a **living, bounded document**.
+## Workflow
 
-Always optimise for these properties:
+1. Run `init` when `AGENTS.md` is missing. This writes the canonical scaffold only.
+2. Run `lint` before editing an existing file. If lint fails, do not guess repairs outside the canonical schema.
+3. Gather only stable, repo-specific facts worth preserving in durable agent guidance.
+4. Run `apply` with structured JSON input to replace whole sections deterministically.
+5. Review the result for repo-specific quality, then keep moving. Do not turn `AGENTS.md` into a changelog.
 
-- Short enough to read quickly
-- Specific to this repository
-- Useful to an implementation agent with no prior context
-- Free from stale, redundant, or inferable content
+## Commands
 
-When updating an existing file, **prune first**.  
-Do not default to appending.
+```sh
+python3 skills/growing-agents-md/scripts/growing_agents_md.py init
+python3 skills/growing-agents-md/scripts/growing_agents_md.py lint
+python3 skills/growing-agents-md/scripts/growing_agents_md.py apply --input agents.json
+```
 
-## What belongs in AGENTS.md
+`apply` expects JSON shaped like:
 
-Include only information that satisfies most of the following:
+```json
+{
+  "project_overview": ["- ..."],
+  "commands": ["~~~sh", "make test", "~~~"],
+  "code_conventions": ["- ..."],
+  "architecture": ["- ..."]
+}
+```
 
-- It is **project-specific**
-- It is **not easily inferable** from code, config, or standard conventions
-- It helps an agent begin or continue implementation without unnecessary clarification
-- Getting it wrong would cause wasted work, confusion, or bad changes
-- It is stable enough to deserve placement in a persistent repository instruction file
+Missing or empty arrays remove that replaceable section. The script hard-fails on non-canonical structure, placeholder leftovers, forbidden catch-all headings, or counted-line budget overflow.
 
-Good candidates include:
+## Content policy
 
-- Repository-specific workflow constraints
-- Important architectural boundaries that are not obvious from local code inspection
-- Non-obvious conventions actually used in this project
-- High-value entry points for build, test, or validation
-- Strong project preferences that materially affect implementation choices
-
-## What does not belong in AGENTS.md
-
-Do **not** include:
-
-- Generic programming advice
-- Restatements of what the code already makes obvious
-- Large command inventories
-- Historical notes
-- Temporary task-specific reminders
-- Long explanations
-- Speculation
-- Catch-all sections such as `Notes`, `Misc`, `Context`, or `Other`
-
-If information is volatile, detailed, or better represented elsewhere, keep it in code, scripts, config, or dedicated docs instead.
-
-## Editing rules
-
-When `AGENTS.md` exists, perform these operations in this order:
-
-1. Remove stale items
-2. Remove redundant items
-3. Compress verbose items
-4. Merge overlapping items
-5. Rewrite unclear items
-6. Add only truly missing, high-value items
-
-Prefer **rewriting the whole file coherently** over incrementally appending text.
-
-## Size discipline
-
-Aim for a compact document.
-
-Target:
-- roughly 20 to 30 lines when possible
-- brief sections
-- terse bullets
-- no paragraph that exists only for explanation
-
-If forced to choose, omit lower-value detail rather than exceed the signal budget.
-
-## Recommended structure
-
-Use a minimal structure like this when creating or rewriting:
-
-- Purpose or scope
-- Key workflow rules
-- Project-specific implementation guidance
-- Validation or completion checks
-- Maintenance note
-
-Do not mechanically preserve an existing structure if it causes bloat.
-
-## Maintenance note policy
-
-A short maintenance note is allowed, but it must stay short.
-
-It should reinforce rules such as:
-
-- keep this file lean
-- delete inferable content
-- rewrite stale guidance
-- prefer stable rules over volatile facts
-
-Do not let the maintenance note become a manifesto.
-
-## Procedure
-
-### Case 1: AGENTS.md is missing
-
-Create a new `AGENTS.md` that:
-
-- is minimal
-- reflects the actual repository
-- avoids placeholders unless unavoidable
-- includes only high-value project guidance
-
-Do not invent repository facts.  
-If repository evidence is insufficient, keep the file narrower rather than padding it.
-
-### Case 2: AGENTS.md exists
-
-Review the file critically.
-
-For each existing item, ask:
-
-- Is this still current?
-- Is this project-specific?
-- Is this non-inferable?
-- Is this worth permanent space?
-- Can this be shortened?
-- Should this be merged or deleted?
-
-Then rewrite the file into a cleaner compact version.
-
-## Decision standard
-
-Every retained line should justify its existence.
-
-A line should usually survive only if removing it would make a competent implementation agent materially more likely to misunderstand the repository, violate a local convention, or pause for clarification.
-
-## Output requirements
-
-When performing this skill:
-
-- Produce the resulting `AGENTS.md`
-- Keep wording direct and compact
-- Prefer imperative phrasing
-- Avoid motivational language
-- Avoid verbosity
-- Avoid duplication
-
-If useful, briefly summarise the main changes as:
-
-- removed
-- compressed
-- added
-
-But the primary output is the improved `AGENTS.md` itself.
+- Keep only repo-specific, non-obvious, stable guidance.
+- Prefer terse bullets and one high-value shell block.
+- Delete stale or inferable content instead of appending.
+- Do not add generic advice, history, or catch-all sections such as `Notes` or `Context`.

--- a/skills/growing-agents-md/scripts/growing_agents_md.py
+++ b/skills/growing-agents-md/scripts/growing_agents_md.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Create, lint, and update the canonical AGENTS.md scaffold."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+TITLE = "# Agent Guidelines"
+FILE_GUARD = "<!-- Do not restructure or delete sections. Update individual values in-place when they change. -->"
+CORE_HEADING = "Core Principles"
+CORE_LINES = (
+    "- Keep this file under 20-30 lines of visible guidance.",
+    "- Keep only repo-specific, non-obvious instructions here.",
+)
+MAINTENANCE_HEADING = "Maintenance Notes"
+MAINTENANCE_GUARD = "<!-- This section is permanent. Do not delete. -->"
+MAINTENANCE_LINES = (
+    "- Delete stale or inferable guidance.",
+    "- Update commands and architecture when workflows change.",
+    "- Keep durable rules here; move detail to dedicated docs.",
+)
+FORBIDDEN_HEADINGS = {"notes", "misc", "context", "important context", "other"}
+
+
+@dataclass(frozen=True)
+class ReplaceableSection:
+    key: str
+    heading: str
+    comment: str
+    placeholder_lines: tuple[str, ...]
+    kind: str
+
+
+REPLACEABLE_SECTIONS = (
+    ReplaceableSection(
+        key="project_overview",
+        heading="Project Overview",
+        comment="<!-- Replace this section in-place. Remove the placeholder line once filled. -->",
+        placeholder_lines=("- [TODO: add stable repo overview]",),
+        kind="bullets",
+    ),
+    ReplaceableSection(
+        key="commands",
+        heading="Commands",
+        comment="<!-- Replace this section in-place. Remove the placeholder block once filled. -->",
+        placeholder_lines=("~~~sh", "# [TODO: add only high-value commands]", "~~~"),
+        kind="commands",
+    ),
+    ReplaceableSection(
+        key="code_conventions",
+        heading="Code Conventions",
+        comment="<!-- Replace this section in-place. Remove the placeholder line once filled. -->",
+        placeholder_lines=("- [TODO: add only non-obvious repo-specific conventions]",),
+        kind="bullets",
+    ),
+    ReplaceableSection(
+        key="architecture",
+        heading="Architecture",
+        comment="<!-- Replace this section in-place. Remove the placeholder line once filled. -->",
+        placeholder_lines=("- [TODO: add only stable architecture boundaries or entry points]",),
+        kind="bullets",
+    ),
+)
+SECTION_BY_HEADING = {section.heading: section for section in REPLACEABLE_SECTIONS}
+SECTION_BY_KEY = {section.key: section for section in REPLACEABLE_SECTIONS}
+SECTION_ORDER = [CORE_HEADING, *(section.heading for section in REPLACEABLE_SECTIONS), MAINTENANCE_HEADING]
+PLACEHOLDER_LINES = {line for section in REPLACEABLE_SECTIONS for line in section.placeholder_lines}
+PLACEHOLDER_TODO_LINES = {line for line in PLACEHOLDER_LINES if "[TODO:" in line}
+
+
+class ToolError(Exception):
+    """Raised for actionable CLI failures."""
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Manage the canonical AGENTS.md scaffold.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="create the canonical scaffold")
+    init_parser.add_argument("--path", default="AGENTS.md", help="target AGENTS.md path")
+
+    lint_parser = subparsers.add_parser("lint", help="lint the canonical scaffold")
+    lint_parser.add_argument("--path", default="AGENTS.md", help="target AGENTS.md path")
+    lint_parser.add_argument("--max-lines", type=int, default=30, help="maximum counted guidance lines")
+
+    apply_parser = subparsers.add_parser("apply", help="rewrite replaceable sections from JSON input")
+    apply_parser.add_argument("--path", default="AGENTS.md", help="target AGENTS.md path")
+    apply_parser.add_argument("--input", required=True, help="JSON file path or '-' for stdin")
+    apply_parser.add_argument("--max-lines", type=int, default=30, help="maximum counted guidance lines")
+
+    return parser.parse_args(argv)
+
+
+def fail(message: str) -> ToolError:
+    return ToolError(message)
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise fail(f"unable to read {path}: {exc}") from exc
+
+
+def read_json_input(raw_path: str) -> dict[str, Any]:
+    if raw_path == "-":
+        try:
+            raw = sys.stdin.read()
+        except OSError as exc:
+            raise fail(f"unable to read JSON from stdin: {exc}") from exc
+    else:
+        source = Path(raw_path)
+        try:
+            raw = source.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise fail(f"unable to read input JSON {source}: {exc}") from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise fail(f"input JSON is invalid: {exc}") from exc
+    if not isinstance(data, dict):
+        raise fail("input JSON must be an object keyed by section name")
+    unexpected = sorted(set(data) - set(SECTION_BY_KEY))
+    if unexpected:
+        raise fail(f"input JSON contains unknown section keys: {', '.join(unexpected)}")
+    return data
+
+
+def write_validated_text(path: Path, text: str, max_lines: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.tmp-", dir=str(path.parent))
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8", newline="\n") as stream:
+            stream.write(text)
+        lint_or_raise(tmp_path, max_lines)
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def trimmed_body(lines: list[str]) -> list[str]:
+    result = list(lines)
+    while result and result[-1] == "":
+        result.pop()
+    return result
+
+
+def collect_headings(lines: list[str]) -> tuple[list[tuple[int, str]], list[str]]:
+    headings: list[tuple[int, str]] = []
+    errors: list[str] = []
+    in_code = False
+
+    for index, line in enumerate(lines):
+        if line == "~~~sh" and not in_code:
+            in_code = True
+            continue
+        if line == "~~~" and in_code:
+            in_code = False
+            continue
+        if in_code:
+            continue
+        if index == 0 and line == TITLE:
+            continue
+        if not line.startswith("#"):
+            continue
+        level = len(line) - len(line.lstrip("#"))
+        if len(line) <= level or line[level] != " ":
+            continue
+        heading_text = line[level + 1 :].strip()
+        if heading_text.lower() in FORBIDDEN_HEADINGS:
+            errors.append(f"forbidden catch-all heading found: {heading_text}")
+            continue
+        if level == 2:
+            headings.append((index, heading_text))
+        else:
+            errors.append(f"unexpected heading outside canonical schema: {line}")
+
+    if in_code:
+        errors.append("unterminated fenced code block")
+
+    return headings, errors
+
+
+def validate_top_matter(lines: list[str]) -> list[str]:
+    errors: list[str] = []
+    if not lines:
+        return ["AGENTS.md is empty"]
+    if lines[0] != TITLE:
+        errors.append(f"first line must be {TITLE!r}")
+    if len(lines) < 2 or lines[1] != "":
+        errors.append("line 2 must be blank")
+    if len(lines) < 3 or lines[2] != FILE_GUARD:
+        errors.append("file guard comment is missing or modified")
+    if len(lines) < 4 or lines[3] != "":
+        errors.append("line 4 must be blank")
+    return errors
+
+
+def validate_heading_order(headings: list[tuple[int, str]]) -> list[str]:
+    errors: list[str] = []
+    names = [name for _index, name in headings]
+
+    for name in names:
+        if name not in SECTION_ORDER:
+            errors.append(f"unexpected section heading: {name}")
+
+    for name in SECTION_ORDER:
+        if names.count(name) > 1:
+            errors.append(f"section heading appears more than once: {name}")
+
+    last_index = -1
+    for name in names:
+        if name not in SECTION_ORDER:
+            continue
+        current_index = SECTION_ORDER.index(name)
+        if current_index <= last_index:
+            errors.append(f"sections are out of canonical order near: {name}")
+            break
+        last_index = current_index
+
+    for name in (CORE_HEADING, MAINTENANCE_HEADING):
+        if name not in names:
+            errors.append(f"missing permanent section: {name}")
+
+    return errors
+
+
+def validate_section_body(
+    heading: str,
+    body: list[str],
+) -> list[str]:
+    if heading == CORE_HEADING:
+        expected = ["", *CORE_LINES]
+        if body != expected:
+            return [f"{heading} must match the canonical scaffold exactly"]
+        return []
+
+    if heading == MAINTENANCE_HEADING:
+        expected = ["", MAINTENANCE_GUARD, *MAINTENANCE_LINES]
+        if body != expected:
+            return [f"{heading} must match the canonical scaffold exactly"]
+        return []
+
+    section = SECTION_BY_HEADING[heading]
+    expected_prefix = ["", section.comment]
+    if body[:2] != expected_prefix:
+        return [f"{heading} must keep its canonical guard comment"]
+    content = body[2:]
+    if not content:
+        return [f"{heading} must contain placeholder content or final content"]
+    return validate_content_lines(section, content, allow_placeholder=True, context=heading)
+
+
+def validate_content_lines(
+    section: ReplaceableSection,
+    content: list[str],
+    *,
+    allow_placeholder: bool,
+    context: str,
+) -> list[str]:
+    if allow_placeholder and content == list(section.placeholder_lines):
+        return []
+
+    errors: list[str] = []
+    if any(line in PLACEHOLDER_TODO_LINES or "[TODO:" in line for line in content):
+        errors.append(f"{context} still contains placeholder tokens")
+        return errors
+
+    if section.kind == "bullets":
+        for line in content:
+            if not line.startswith("- "):
+                errors.append(f"{context} must contain bullet lines only")
+                break
+        return errors
+
+    if content[0] != "~~~sh" or content[-1] != "~~~":
+        return [f"{context} must contain exactly one fenced sh block"]
+    inner = content[1:-1]
+    if not inner:
+        return [f"{context} fenced sh block must not be empty"]
+    if any(line.startswith("~~~") for line in inner):
+        return [f"{context} must contain exactly one fenced sh block"]
+    return errors
+
+
+def counted_guidance_lines(lines: list[str]) -> int:
+    count = 0
+    in_code = False
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if line == "~~~sh" and not in_code:
+            in_code = True
+            continue
+        if line == "~~~" and in_code:
+            in_code = False
+            continue
+        if stripped in PLACEHOLDER_TODO_LINES:
+            continue
+        if not in_code:
+            if stripped.startswith("<!--") and stripped.endswith("-->"):
+                continue
+            if stripped in {"---", "***", "___"}:
+                continue
+            if stripped.startswith("#"):
+                continue
+        count += 1
+    return count
+
+
+def lint_text(text: str, max_lines: int) -> list[str]:
+    if max_lines <= 0:
+        return ["--max-lines must be greater than zero"]
+
+    lines = text.splitlines()
+    errors = validate_top_matter(lines)
+    headings, heading_errors = collect_headings(lines)
+    errors.extend(heading_errors)
+    errors.extend(validate_heading_order(headings))
+
+    positions = {name: index for index, name in headings if name in SECTION_ORDER}
+    end_of_file = len(lines)
+    for section_index, heading in enumerate(SECTION_ORDER):
+        if heading not in positions:
+            continue
+        start = positions[heading]
+        later_positions = [
+            positions[next_heading]
+            for next_heading in SECTION_ORDER[section_index + 1 :]
+            if next_heading in positions
+        ]
+        end = min(later_positions) if later_positions else end_of_file
+        body = trimmed_body(lines[start + 1 : end])
+        errors.extend(validate_section_body(heading, body))
+
+    count = counted_guidance_lines(lines)
+    if count > max_lines:
+        errors.append(f"counted guidance lines exceed budget: {count} > {max_lines}")
+
+    return errors
+
+
+def lint_or_raise(path: Path, max_lines: int) -> None:
+    if not path.exists():
+        raise fail(f"{path} does not exist")
+    errors = lint_text(read_text(path), max_lines)
+    if errors:
+        raise fail("\n".join(f"error: {message}" for message in errors))
+
+
+def render_document(section_content: dict[str, list[str] | None]) -> str:
+    lines = [TITLE, "", FILE_GUARD, "", f"## {CORE_HEADING}", "", *CORE_LINES, ""]
+    for section in REPLACEABLE_SECTIONS:
+        content = section_content[section.key]
+        if not content:
+            continue
+        lines.extend([f"## {section.heading}", "", section.comment, *content, ""])
+    lines.extend([f"## {MAINTENANCE_HEADING}", "", MAINTENANCE_GUARD, *MAINTENANCE_LINES])
+    return "\n".join(lines) + "\n"
+
+
+def scaffold_content() -> dict[str, list[str] | None]:
+    return {section.key: list(section.placeholder_lines) for section in REPLACEABLE_SECTIONS}
+
+
+def load_apply_content(data: dict[str, Any]) -> dict[str, list[str] | None]:
+    rendered: dict[str, list[str] | None] = {}
+    for section in REPLACEABLE_SECTIONS:
+        raw_value = data.get(section.key)
+        if raw_value is None:
+            rendered[section.key] = None
+            continue
+        if not isinstance(raw_value, list):
+            raise fail(f"{section.key} must be an array of markdown lines")
+        if not raw_value:
+            rendered[section.key] = None
+            continue
+        if not all(isinstance(item, str) for item in raw_value):
+            raise fail(f"{section.key} must contain strings only")
+        if any("\n" in item or "\r" in item for item in raw_value):
+            raise fail(f"{section.key} items must be single markdown lines")
+        errors = validate_content_lines(
+            section,
+            list(raw_value),
+            allow_placeholder=False,
+            context=section.key,
+        )
+        if errors:
+            raise fail("\n".join(f"error: {message}" for message in errors))
+        rendered[section.key] = list(raw_value)
+    return rendered
+
+
+def cmd_init(path: Path) -> None:
+    if path.exists():
+        raise fail(f"{path} already exists")
+    write_validated_text(path, render_document(scaffold_content()), max_lines=30)
+
+
+def cmd_lint(path: Path, max_lines: int) -> None:
+    lint_or_raise(path, max_lines)
+
+
+def cmd_apply(path: Path, input_path: str, max_lines: int) -> None:
+    if not path.exists():
+        raise fail(f"{path} does not exist")
+    lint_or_raise(path, max_lines)
+    content = load_apply_content(read_json_input(input_path))
+    rendered = render_document(content)
+    errors = lint_text(rendered, max_lines)
+    if errors:
+        raise fail("\n".join(f"error: {message}" for message in errors))
+    write_validated_text(path, rendered, max_lines)
+    lint_or_raise(path, max_lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    path = Path(args.path)
+
+    try:
+        if args.command == "init":
+            cmd_init(path)
+        elif args.command == "lint":
+            cmd_lint(path, args.max_lines)
+        elif args.command == "apply":
+            cmd_apply(path, args.input, args.max_lines)
+        else:
+            raise fail(f"unknown command: {args.command}")
+    except ToolError as exc:
+        message = str(exc)
+        if message:
+            print(message, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/growing-agents-md/scripts/growing_agents_md.py
+++ b/skills/growing-agents-md/scripts/growing_agents_md.py
@@ -234,6 +234,14 @@ def validate_heading_order(headings: list[tuple[int, str]]) -> list[str]:
     return errors
 
 
+def validate_outer_structure(lines: list[str], headings: list[tuple[int, str]]) -> list[str]:
+    if not headings:
+        return []
+    if headings[0][0] != 4:
+        return ["unexpected content before the first canonical section"]
+    return []
+
+
 def validate_section_body(
     heading: str,
     body: list[str],
@@ -327,6 +335,7 @@ def lint_text(text: str, max_lines: int) -> list[str]:
     headings, heading_errors = collect_headings(lines)
     errors.extend(heading_errors)
     errors.extend(validate_heading_order(headings))
+    errors.extend(validate_outer_structure(lines, headings))
 
     positions = {name: index for index, name in headings if name in SECTION_ORDER}
     end_of_file = len(lines)

--- a/skills/growing-agents-md/scripts/test_growing_agents_md.py
+++ b/skills/growing-agents-md/scripts/test_growing_agents_md.py
@@ -215,6 +215,22 @@ class GrowingAgentsMdTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("missing permanent section: Maintenance Notes", result.stderr)
 
+    def test_lint_fails_on_stray_content_before_first_canonical_section(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write(
+                root / "AGENTS.md",
+                EXPECTED_SCAFFOLD.replace(
+                    "## Core Principles",
+                    "stray line\n\n## Core Principles",
+                ),
+            )
+
+            result = run_script(root, "lint", check=False)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unexpected content before the first canonical section", result.stderr)
+
     def test_lint_fails_when_budget_is_exceeded(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/skills/growing-agents-md/scripts/test_growing_agents_md.py
+++ b/skills/growing-agents-md/scripts/test_growing_agents_md.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""CLI tests for growing_agents_md.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("growing_agents_md.py")
+EXPECTED_SCAFFOLD = """# Agent Guidelines
+
+<!-- Do not restructure or delete sections. Update individual values in-place when they change. -->
+
+## Core Principles
+
+- Keep this file under 20-30 lines of visible guidance.
+- Keep only repo-specific, non-obvious instructions here.
+
+## Project Overview
+
+<!-- Replace this section in-place. Remove the placeholder line once filled. -->
+- [TODO: add stable repo overview]
+
+## Commands
+
+<!-- Replace this section in-place. Remove the placeholder block once filled. -->
+~~~sh
+# [TODO: add only high-value commands]
+~~~
+
+## Code Conventions
+
+<!-- Replace this section in-place. Remove the placeholder line once filled. -->
+- [TODO: add only non-obvious repo-specific conventions]
+
+## Architecture
+
+<!-- Replace this section in-place. Remove the placeholder line once filled. -->
+- [TODO: add only stable architecture boundaries or entry points]
+
+## Maintenance Notes
+
+<!-- This section is permanent. Do not delete. -->
+- Delete stale or inferable guidance.
+- Update commands and architecture when workflows change.
+- Keep durable rules here; move detail to dedicated docs.
+"""
+
+
+def run_script(
+    cwd: Path,
+    *args: str,
+    input_text: str | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=str(cwd),
+        input=input_text,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"command failed: {sys.executable} {SCRIPT} {' '.join(args)}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def write_json(path: Path, payload: dict[str, list[str]]) -> None:
+    write(path, json.dumps(payload, indent=2) + "\n")
+
+
+class GrowingAgentsMdTests(unittest.TestCase):
+    def test_lint_fails_when_agents_md_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_script(Path(tmp), "lint", check=False)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("does not exist", result.stderr)
+
+    def test_init_creates_literal_scaffold_and_lint_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+
+            run_script(root, "init")
+
+            self.assertEqual((root / "AGENTS.md").read_text(encoding="utf-8"), EXPECTED_SCAFFOLD)
+            lint = run_script(root, "lint")
+            self.assertEqual(lint.returncode, 0)
+
+    def test_init_fails_without_rewriting_existing_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            original = "# custom\n"
+            write(root / "AGENTS.md", original)
+
+            result = run_script(root, "init", check=False)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual((root / "AGENTS.md").read_text(encoding="utf-8"), original)
+
+    def test_apply_populates_sections_and_removes_placeholders(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_script(root, "init")
+            payload_path = root / "apply.json"
+            write_json(
+                payload_path,
+                {
+                    "project_overview": [
+                        "- Stores reusable agent skills and small supporting docs.",
+                    ],
+                    "commands": [
+                        "~~~sh",
+                        "python3 -m unittest skills/growing-agents-md/scripts/test_growing_agents_md.py",
+                        "~~~",
+                    ],
+                    "code_conventions": [
+                        "- Keep skill text compact and operational.",
+                    ],
+                    "architecture": [
+                        "- Script-backed skills keep deterministic rules in scripts/ and prose in SKILL.md.",
+                    ],
+                },
+            )
+
+            run_script(root, "apply", "--input", str(payload_path))
+
+            text = (root / "AGENTS.md").read_text(encoding="utf-8")
+            self.assertIn("## Project Overview", text)
+            self.assertIn("## Commands", text)
+            self.assertIn("## Code Conventions", text)
+            self.assertIn("## Architecture", text)
+            self.assertNotIn("[TODO:", text)
+            self.assertIn("## Maintenance Notes", text)
+            self.assertEqual(run_script(root, "lint").returncode, 0)
+
+    def test_apply_removes_empty_or_missing_replaceable_sections(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_script(root, "init")
+
+            result = run_script(
+                root,
+                "apply",
+                "--input",
+                "-",
+                input_text=json.dumps(
+                    {
+                        "project_overview": ["- Keeps only durable repo-specific guidance."],
+                        "commands": [],
+                    }
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0)
+            text = (root / "AGENTS.md").read_text(encoding="utf-8")
+            self.assertIn("## Project Overview", text)
+            self.assertNotIn("## Commands", text)
+            self.assertNotIn("## Code Conventions", text)
+            self.assertNotIn("## Architecture", text)
+
+    def test_lint_fails_when_placeholder_tokens_remain_in_populated_section(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write(
+                root / "AGENTS.md",
+                EXPECTED_SCAFFOLD.replace(
+                    "- [TODO: add stable repo overview]",
+                    "- Stable overview\n- [TODO: add stable repo overview]",
+                ),
+            )
+
+            result = run_script(root, "lint", check=False)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Project Overview still contains placeholder tokens", result.stderr)
+
+    def test_lint_fails_on_forbidden_catch_all_heading(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write(
+                root / "AGENTS.md",
+                EXPECTED_SCAFFOLD.replace(
+                    "## Maintenance Notes",
+                    "## Notes\n\n- Generic filler.\n\n## Maintenance Notes",
+                ),
+            )
+
+            result = run_script(root, "lint", check=False)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("forbidden catch-all heading found: Notes", result.stderr)
+
+    def test_lint_fails_on_structural_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write(root / "AGENTS.md", EXPECTED_SCAFFOLD.replace("## Maintenance Notes\n", ""))
+
+            result = run_script(root, "lint", check=False)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("missing permanent section: Maintenance Notes", result.stderr)
+
+    def test_lint_fails_when_budget_is_exceeded(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_script(root, "init")
+            payload_path = root / "apply.json"
+            write_json(
+                payload_path,
+                {
+                    "project_overview": [f"- overview line {index}" for index in range(1, 27)],
+                    "commands": ["~~~sh", "git status", "~~~"],
+                    "code_conventions": [],
+                    "architecture": [],
+                },
+            )
+
+            result = run_script(root, "apply", "--input", str(payload_path), check=False)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("counted guidance lines exceed budget", result.stderr)
+
+    def test_apply_hard_fails_on_noncanonical_target_without_rewriting(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            broken = EXPECTED_SCAFFOLD.replace(
+                "<!-- Replace this section in-place. Remove the placeholder line once filled. -->",
+                "<!-- broken -->",
+                1,
+            )
+            write(root / "AGENTS.md", broken)
+            payload_path = root / "apply.json"
+            write_json(payload_path, {"project_overview": ["- Stable repo summary."]})
+
+            result = run_script(root, "apply", "--input", str(payload_path), check=False)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual((root / "AGENTS.md").read_text(encoding="utf-8"), broken)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a deterministic companion script for canonical AGENTS.md init, lint, and apply
- add tests for scaffold validation, placeholder rules, section removal, and budget failures
- rewrite the growing-agents-md skill to use the script-first maintenance workflow

Closes #36