### PR TITLE
Add github-driven-workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Each skill must live at `skills/<skill-name>/SKILL.md`.
 
 - `devcontainer-cli`: review, validate, and troubleshoot Dev Container setup with explicit CLI-first guidance
 
+### Delivery workflow
+
+- `github-driven-workflow`: enforce issue-first, PR-gated delivery with no direct main pushes, independent review requirement, and deterministic merge gates
+
 ## Naming guidance
 
 Prefer short, command-friendly names.

--- a/skills/README.md
+++ b/skills/README.md
@@ -27,3 +27,4 @@ Current skills:
 - light-orchestration
 - deslop-history
 - devcontainer-cli
+- github-driven-workflow

--- a/skills/github-driven-workflow/SKILL.md
+++ b/skills/github-driven-workflow/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: github-driven-workflow
+description: Enforce issue-first, PR-gated delivery with no direct main pushes, independent review requirement, and deterministic merge gates. Use when implementing from a GitHub issue, creating or merging a PR, protecting main from direct pushes, requiring independent review, or checking merge readiness.
+---
+
+# github-driven-workflow
+
+Enforce a fail-closed GitHub delivery workflow: every change traces to an issue, lands on a branch, ships through a PR, and merges only when all gates pass.
+
+## When to use
+
+Use this skill when:
+
+- the user asks to implement something from a GitHub issue
+- the user asks to open, update, or merge a PR
+- the user asks to protect `main` from direct pushes
+- the user asks to enforce issue-first or PR-driven delivery
+- the user asks to require independent review before merge
+- the user asks to check or enforce merge gate readiness
+
+## Workflow
+
+### 1. Resolve state
+
+Before writing any code:
+
+- Identify the target GitHub issue.
+- Confirm the default branch (`main` or equivalent).
+- Confirm no uncommitted changes that belong to a different issue.
+
+If no issue is identified, stop. Request or create one according to the user's available permissions before continuing.
+
+### 2. Check issue readiness
+
+Inspect the issue for:
+
+- **Scope**: what is in scope and what is not.
+- **Acceptance criteria**: conditions under which the issue is complete.
+
+If either is missing or ambiguous, update the issue or request updates before writing any code.
+
+### 3. Branch
+
+- Do not implement on `main`.
+- Do not push directly to `main`.
+- Create a branch named `issue-<id>-<slug>` from the current default branch.
+- Switch to that branch before making any changes.
+
+### 4. Implement
+
+Implement the change on the `issue-<id>-<slug>` branch.
+
+### 5. Validate locally
+
+Run the validation commands appropriate to this repository. Record the commands and their output.
+
+### 6. Create a PR
+
+The PR must include:
+
+- `Closes #<issue>` in the body.
+- A validation summary with recorded commands and results.
+- Markdown task checkboxes (`- [ ]`) only for known remaining work; every unchecked box blocks merge.
+
+### 7. Acquire independent review
+
+A qualifying independent review is one of:
+
+- A GitHub PR review or PR comment by an actor other than the implementation author.
+- A Copilot reviewer result visible on the PR.
+- A `@codex` review or comment visible on the PR.
+- A subagent review only when the environment explicitly supports subagents and the PR body contains the subagent review summary and identity.
+
+If no qualifying route is available, stop and request an external reviewer. Do not treat self-review, local notes, or an unlinked claim as qualifying evidence.
+
+### 8. Check merge gates
+
+All of the following must pass before merge:
+
+- PR is open and not draft.
+- All GitHub-reported required checks are success.
+- If no required checks are reported, all present checks must be success.
+- If CI status cannot be read, stop.
+- GitHub unresolved review thread count is zero.
+- If review thread state cannot be read, stop.
+- PR body has no unchecked Markdown task boxes (`- [ ]` or `* [ ]`).
+- PR has no `blocked`, `do-not-merge`, or `needs-decision` label.
+- Qualifying independent review evidence exists.
+
+### 9. Merge
+
+Merge only when every gate passes. If any gate fails, fix, revalidate, or leave the PR open with a clear blocking reason stated in a PR comment.
+
+## Fail-closed behavior
+
+Stop before implementation or merge when any required state cannot be verified.
+
+Stop conditions:
+
+- Issue is missing or ambiguous.
+- Issue Scope or Acceptance is missing.
+- Implementation branch is missing or the current branch is `main`.
+- PR is missing.
+- PR lacks `Closes #<issue>`.
+- Independent review evidence is missing.
+- CI is failing, pending, or unreadable.
+- Unresolved review thread count is nonzero or unreadable.
+- PR body has unchecked TODO checkboxes.
+- PR has a blocking label.
+- PR is draft.
+
+When stopped, state the exact condition that blocked progress and the action needed to unblock it.
+
+## Scope
+
+This skill provides procedural guidance only. It does not configure GitHub branch protection rules, CI workflows, or repository permissions.

--- a/skills/github-driven-workflow/SKILL.md
+++ b/skills/github-driven-workflow/SKILL.md
@@ -72,35 +72,54 @@ Do not treat self-review, local notes, or an unlinked claim as qualifying.
 
 #### Requesting Copilot review
 
-Copilot code review requires the feature to be enabled in the repository settings. Check availability by attempting to add the reviewer:
+Copilot code review requires the `copilot-pull-request-reviewer` GitHub App to be installed on the repository. Assign Copilot as a reviewer using the REST API with a JSON body:
 
 ```sh
 gh api repos/<owner>/<repo>/pulls/<N>/requested_reviewers \
-  -X POST -f 'reviewers[]=copilot-ai'
+  -X POST --input - <<'EOF'
+{"reviewers": ["copilot-pull-request-reviewer[bot]"]}
+EOF
 ```
 
-- HTTP 200 → reviewer added; Copilot review is available and was requested.
-- HTTP 422 ("not a collaborator") → Copilot code review is not enabled for this repository. Use a different qualifying route.
+- HTTP 200 with `requested_reviewers` containing `"login": "Copilot"` → reviewer added successfully.
+- HTTP 422 ("not a collaborator") → the Copilot app is not installed on this repository. Use a different qualifying route.
 
-Verify completion: poll `gh pr view <N> --json reviews` until a review entry with `author.login` of `github-copilot[bot]` appears with `state` of `APPROVED`, `CHANGES_REQUESTED`, or `COMMENTED`.
+Do not use `-f 'reviewers[]=Copilot'` or `gh pr edit --add-reviewer Copilot`; both silently fail or produce a GraphQL error.
+
+Verify assignment:
+```sh
+gh pr view <N> --json reviewRequests \
+  --jq '[.reviewRequests[].requestedReviewer.login]'
+```
+Should include `"Copilot"`.
+
+Verify completion: poll `gh pr view <N> --json reviews` until a review entry with `author.login` of `copilot-pull-request-reviewer[bot]` appears.
 
 #### Requesting @codex review
 
-@codex review requires the Codex GitHub App to be installed on the repository. Request a review by posting a comment:
+Post a mention comment to request a @codex review:
 
 ```sh
 gh api repos/<owner>/<repo>/issues/<N>/comments \
   -X POST -f body='@codex please review this PR'
 ```
 
-The comment always posts successfully regardless of whether Codex is installed. Verify completion by polling the comments endpoint until a comment from a bot with `login` containing `codex` appears:
+The comment always posts successfully. Verify that Codex received the notification:
+```sh
+gh api repos/<owner>/<repo>/issues/<N>/timeline \
+  --jq '[.[] | select(.event == "mentioned") | .actor.login]'
+```
+Should include `"codex"`.
 
+Verify completion by polling comments until a response from the Codex bot appears:
 ```sh
 gh api repos/<owner>/<repo>/issues/<N>/comments \
-  --jq '[.[] | select(.user.login | contains("codex")) | {author: .user.login, body: .body}]'
+  --jq '[.[] | select(.user.login | ascii_downcase | contains("codex")) | {author: .user.login, body: .body[:120]}]'
 ```
 
-If no Codex response appears after a reasonable wait, Codex is not installed. Use a different qualifying route.
+If no Codex response appears after a reasonable wait, the Codex app may not be active on this repository. Use a different qualifying route.
+
+A @codex review counts as independent even when Codex opened the PR; the review agent invoked by mention runs in a separate context.
 
 #### Waiting for review
 

--- a/skills/github-driven-workflow/SKILL.md
+++ b/skills/github-driven-workflow/SKILL.md
@@ -13,6 +13,13 @@ This skill governs the entire delivery lifecycle. It is assigned by an orchestra
 
 Use this skill when an orchestrator or project instructions assign it to govern a delivery task. It controls the full lifecycle from issue intake through merge.
 
+Assign this skill for tasks that involve:
+
+- implementing a change from a GitHub issue (issue-first delivery)
+- delivering work through a PR (PR-gated delivery)
+- requiring independent review before merge
+- checking or enforcing merge gate readiness
+
 Do not invoke this skill for a single sub-step (e.g. "open a PR" or "check CI") unless the full workflow context is already established and the orchestrator has scoped the invocation explicitly.
 
 ## Workflow
@@ -61,14 +68,14 @@ The PR must include:
 
 ### 7. Acquire independent review
 
-A qualifying independent review is one of:
+A qualifying independent review is a formal GitHub PR review submitted by an actor other than the implementation author:
 
-- A GitHub PR review or PR comment by a human actor other than the implementation author.
+- A GitHub PR review (approved, changes requested, or commented) by a human actor other than the implementation author.
 - A Copilot code review result visible on the PR.
-- A `@codex` review comment visible on the PR.
+- A `@codex` review visible on the PR.
 - A subagent review only when the environment explicitly supports subagents and the PR body contains the subagent review summary and identity.
 
-Do not treat self-review, local notes, or an unlinked claim as qualifying.
+PR comments alone do not qualify. Self-reviews, local notes, and unlinked claims do not qualify.
 
 #### Requesting Copilot review
 
@@ -171,15 +178,16 @@ gh api graphql -f query='
 {
   repository(owner: "<owner>", name: "<repo>") {
     pullRequest(number: <N>) {
-      reviewThreads(first: 50) {
+      reviewThreads(first: 100) {
         nodes { isResolved }
+        pageInfo { hasNextPage endCursor }
       }
     }
   }
 }'
 ```
 
-Count nodes where `isResolved` is `false`. Must be zero. If the query errors, stop.
+Count nodes where `isResolved` is `false`. Must be zero. If `pageInfo.hasNextPage` is `true`, repeat with `after: "<endCursor>"` until all pages are checked. If the query errors, stop.
 
 **Unchecked task boxes**
 
@@ -211,7 +219,7 @@ Stop conditions:
 
 - Issue is missing or ambiguous.
 - Issue Scope or Acceptance is missing.
-- Current branch is `main` and no implementation branch exists.
+- Current branch is `main`.
 - PR is missing.
 - PR lacks `Closes #<issue>`.
 - Independent review evidence is missing.

--- a/skills/github-driven-workflow/SKILL.md
+++ b/skills/github-driven-workflow/SKILL.md
@@ -1,22 +1,19 @@
 ---
 name: github-driven-workflow
-description: Enforce issue-first, PR-gated delivery with no direct main pushes, independent review requirement, and deterministic merge gates. Use when implementing from a GitHub issue, creating or merging a PR, protecting main from direct pushes, requiring independent review, or checking merge readiness.
+description: Enforce issue-first, PR-gated delivery with no direct main pushes, independent review requirement, and deterministic merge gates. Use when assigned by an orchestrator to govern the full delivery lifecycle for a GitHub issue, when enforcing PR-gated delivery, when requiring independent review, or when checking merge readiness.
 ---
 
 # github-driven-workflow
 
 Enforce a fail-closed GitHub delivery workflow: every change traces to an issue, lands on a branch, ships through a PR, and merges only when all gates pass.
 
+This skill governs the entire delivery lifecycle. It is assigned by an orchestrator or project rules to bind the implementing agent to this workflow for the duration of a task.
+
 ## When to use
 
-Use this skill when:
+Use this skill when an orchestrator or project instructions assign it to govern a delivery task. It controls the full lifecycle from issue intake through merge.
 
-- the user asks to implement something from a GitHub issue
-- the user asks to open, update, or merge a PR
-- the user asks to protect `main` from direct pushes
-- the user asks to enforce issue-first or PR-driven delivery
-- the user asks to require independent review before merge
-- the user asks to check or enforce merge gate readiness
+Do not invoke this skill for a single sub-step (e.g. "open a PR" or "check CI") unless the full workflow context is already established and the orchestrator has scoped the invocation explicitly.
 
 ## Workflow
 
@@ -28,7 +25,7 @@ Before writing any code:
 - Confirm the default branch (`main` or equivalent).
 - Confirm no uncommitted changes that belong to a different issue.
 
-If no issue is identified, stop. Request or create one according to the user's available permissions before continuing.
+If no issue is identified, stop. Request or create one before continuing.
 
 ### 2. Check issue readiness
 
@@ -66,30 +63,126 @@ The PR must include:
 
 A qualifying independent review is one of:
 
-- A GitHub PR review or PR comment by an actor other than the implementation author.
-- A Copilot reviewer result visible on the PR.
-- A `@codex` review or comment visible on the PR.
+- A GitHub PR review or PR comment by a human actor other than the implementation author.
+- A Copilot code review result visible on the PR.
+- A `@codex` review comment visible on the PR.
 - A subagent review only when the environment explicitly supports subagents and the PR body contains the subagent review summary and identity.
 
-If no qualifying route is available, stop and request an external reviewer. Do not treat self-review, local notes, or an unlinked claim as qualifying evidence.
+Do not treat self-review, local notes, or an unlinked claim as qualifying.
+
+#### Requesting Copilot review
+
+Copilot code review requires the feature to be enabled in the repository settings. Check availability by attempting to add the reviewer:
+
+```sh
+gh api repos/<owner>/<repo>/pulls/<N>/requested_reviewers \
+  -X POST -f 'reviewers[]=copilot-ai'
+```
+
+- HTTP 200 → reviewer added; Copilot review is available and was requested.
+- HTTP 422 ("not a collaborator") → Copilot code review is not enabled for this repository. Use a different qualifying route.
+
+Verify completion: poll `gh pr view <N> --json reviews` until a review entry with `author.login` of `github-copilot[bot]` appears with `state` of `APPROVED`, `CHANGES_REQUESTED`, or `COMMENTED`.
+
+#### Requesting @codex review
+
+@codex review requires the Codex GitHub App to be installed on the repository. Request a review by posting a comment:
+
+```sh
+gh api repos/<owner>/<repo>/issues/<N>/comments \
+  -X POST -f body='@codex please review this PR'
+```
+
+The comment always posts successfully regardless of whether Codex is installed. Verify completion by polling the comments endpoint until a comment from a bot with `login` containing `codex` appears:
+
+```sh
+gh api repos/<owner>/<repo>/issues/<N>/comments \
+  --jq '[.[] | select(.user.login | contains("codex")) | {author: .user.login, body: .body}]'
+```
+
+If no Codex response appears after a reasonable wait, Codex is not installed. Use a different qualifying route.
+
+#### Waiting for review
+
+Both Copilot and @codex reviews are asynchronous. After requesting:
+
+1. Stop and wait. Do not attempt to merge.
+2. Re-check the relevant endpoint periodically.
+3. If no response appears, state the blocking condition and ask for an alternative reviewer.
+
+If no qualifying route is available, stop and request a human reviewer via `gh pr edit <N> --add-reviewer <login>`.
 
 ### 8. Check merge gates
 
-All of the following must pass before merge:
+Run all checks before merging. Each check uses a concrete command.
 
-- PR is open and not draft.
-- All GitHub-reported required checks are success.
-- If no required checks are reported, all present checks must be success.
-- If CI status cannot be read, stop.
-- GitHub unresolved review thread count is zero.
-- If review thread state cannot be read, stop.
-- PR body has no unchecked Markdown task boxes (`- [ ]` or `* [ ]`).
-- PR has no `blocked`, `do-not-merge`, or `needs-decision` label.
-- Qualifying independent review evidence exists.
+**PR state**
+
+```sh
+gh pr view <N> --json state,isDraft \
+  --jq '{open: (.state == "OPEN"), notDraft: (.isDraft == false)}'
+```
+
+Both must be `true`.
+
+**CI checks**
+
+```sh
+gh pr view <N> --json statusCheckRollup \
+  --jq '.statusCheckRollup | map({name, state})'
+```
+
+- If the array is empty, no checks are configured; this gate passes.
+- If any check has `state` other than `SUCCESS`, stop.
+- If the command errors, stop.
+
+**Labels**
+
+```sh
+gh pr view <N> --json labels \
+  --jq '[.labels[].name] | any(. == "blocked" or . == "do-not-merge" or . == "needs-decision")'
+```
+
+Must return `false`.
+
+**Unresolved review threads**
+
+```sh
+gh api graphql -f query='
+{
+  repository(owner: "<owner>", name: "<repo>") {
+    pullRequest(number: <N>) {
+      reviewThreads(first: 50) {
+        nodes { isResolved }
+      }
+    }
+  }
+}'
+```
+
+Count nodes where `isResolved` is `false`. Must be zero. If the query errors, stop.
+
+**Unchecked task boxes**
+
+```sh
+gh pr view <N> --json body \
+  --jq '.body | test("- \\[ \\]|\\* \\[ \\]")'
+```
+
+Must return `false`.
+
+**Independent review evidence**
+
+```sh
+gh pr view <N> --json reviews \
+  --jq '[.reviews[] | {author: .author.login, state: .state}]'
+```
+
+At least one qualifying review must be present. Self-reviews (same login as the implementation author) do not qualify.
 
 ### 9. Merge
 
-Merge only when every gate passes. If any gate fails, fix, revalidate, or leave the PR open with a clear blocking reason stated in a PR comment.
+Merge only when every gate passes. If any gate fails, fix, revalidate, or leave the PR open with a PR comment stating the exact blocking condition.
 
 ## Fail-closed behavior
 
@@ -99,13 +192,13 @@ Stop conditions:
 
 - Issue is missing or ambiguous.
 - Issue Scope or Acceptance is missing.
-- Implementation branch is missing or the current branch is `main`.
+- Current branch is `main` and no implementation branch exists.
 - PR is missing.
 - PR lacks `Closes #<issue>`.
 - Independent review evidence is missing.
-- CI is failing, pending, or unreadable.
-- Unresolved review thread count is nonzero or unreadable.
-- PR body has unchecked TODO checkboxes.
+- CI check state is not `SUCCESS`, is pending, or the command errored.
+- Unresolved review thread count is nonzero or the query errored.
+- PR body has unchecked task boxes.
 - PR has a blocking label.
 - PR is draft.
 


### PR DESCRIPTION
## Summary

- Adds `skills/github-driven-workflow/SKILL.md` with `name: github-driven-workflow`
- Encodes fail-closed issue-first, PR-gated delivery: issue readiness check → branch → implement → validate → PR → independent review → merge gates → merge
- Defines deterministic merge gate rules and all stop conditions
- Updates `skills/README.md` and root `README.md`

Closes #37

## Validation

- `SKILL.md` has correct frontmatter `name:` and description with all required trigger phrases (issue-first, PR-gated, no direct main, independent review, merge-gate)
- `When to use` section covers all five trigger scenarios from the issue
- Fail-closed stop conditions listed explicitly
- No out-of-scope files added (no `.apm/`, no hooks, no agents)
- `skills/README.md` lists `github-driven-workflow`
- Root `README.md` lists `github-driven-workflow` under new "Delivery workflow" section

## Test plan

- [x] Verify acceptance criteria in #37 against `SKILL.md` content