### PR TITLE
Add randomness skill with PRNG script and String Seed fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Each skill must live at `skills/<skill-name>/SKILL.md`.
 
 - `github-driven-workflow`: enforce issue-first, PR-gated delivery with no direct main pushes, independent review requirement, and deterministic merge gates
 
+### Randomness
+
+- `randomness`: prefer a bundled PRNG script for random selection; fall back to a String Seed prompt pattern only for low-stakes or creative-diversity use
+
 ## Naming guidance
 
 Prefer short, command-friendly names.

--- a/skills/README.md
+++ b/skills/README.md
@@ -28,3 +28,4 @@ Current skills:
 - deslop-history
 - devcontainer-cli
 - github-driven-workflow
+- randomness

--- a/skills/randomness/SKILL.md
+++ b/skills/randomness/SKILL.md
@@ -60,11 +60,10 @@ Weighted JSON output includes the per-item weights:
 
 ## String Seed fallback (secondary path)
 
-Use this pattern **only when**:
+Use String Seed prompting only for low-stakes tasks, and only in either of these cases:
 
-- Tool execution is unavailable
-- The goal is creative diversification, not PRNG-backed sampling
-- The task is low-stakes
+- Tool execution is unavailable, and a random or probabilistic choice is still needed.
+- Tool execution is available, but the goal is creative diversification rather than PRNG-backed sampling.
 
 ### Fallback procedure
 

--- a/skills/randomness/SKILL.md
+++ b/skills/randomness/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: randomness
+description: Use when a task explicitly requires random selection, probabilistic sampling, stochastic tie-breaking, or diverse creative generation. Prefer the bundled PRNG script when tool execution is available. Use prompt-only String Seed fallback only for low-stakes or creative-diversity cases. Do not use for security-sensitive, scientific, benchmark, lottery, or correctness-critical randomness.
+---
+
+# Randomness
+
+Use this skill when the user asks for random selection, probabilistic sampling, stochastic tie-breaking, or diverse creative generation.
+
+## Priority order
+
+1. **Script-backed randomness** (primary): Use the bundled PRNG script when tool execution is available.
+2. **String Seed fallback** (secondary): Use only when tools are unavailable or the goal is creative diversification rather than actual randomness.
+3. **Refuse or redirect**: For security-sensitive, fairness-sensitive, scientific, benchmark, simulation, lottery, or reproducibility-critical tasks, redirect to explicit external tooling.
+
+## Script-backed randomness (primary path)
+
+When tool execution is available, use the bundled script:
+
+```sh
+python3 skills/randomness/scripts/random_choice.py --uniform A B C
+python3 skills/randomness/scripts/random_choice.py --weighted A:0.2 B:0.8
+```
+
+The script uses Python's `random` module (PRNG). It is not cryptographically secure and not suitable for fair lotteries or security-sensitive tasks.
+
+### Uniform choice
+
+```sh
+python3 skills/randomness/scripts/random_choice.py --uniform option1 option2 option3
+```
+
+Outputs the selected item to stdout.
+
+### Weighted choice
+
+```sh
+python3 skills/randomness/scripts/random_choice.py --weighted item1:0.3 item2:0.7
+```
+
+Format: `item:weight`. Weights must be non-negative, finite, and sum to greater than zero.
+
+### JSON output
+
+```sh
+python3 skills/randomness/scripts/random_choice.py --uniform A B C --json
+```
+
+Outputs: `{"mode": "uniform", "selected": "A", "method": "python random module"}`
+
+## String Seed fallback (secondary path)
+
+Use this pattern **only when**:
+
+- Tool execution is unavailable
+- The goal is creative diversification, not statistically valid randomness
+- The task is low-stakes
+
+### Fallback procedure
+
+When using String Seed as a fallback:
+
+1. Generate a random-looking string of 24–40 mixed characters.
+2. Use the **entire seed string** as a control signal for the downstream task.
+3. Do not choose by intuition or by the most natural/default answer.
+4. Map the seed to the requested choice space or diversity dimensions.
+
+**The seed is a control signal, not decorative text.**
+
+### Prompt template for probabilistic choice
+
+```text
+First, generate a random-looking string of 24–40 mixed characters.
+Then, use the entire string as a seed for the following task.
+Do not choose by intuition or by the most natural/default answer.
+
+For uniform choice among n options:
+- Use the whole seed string to derive a number.
+- Take that number modulo n.
+
+For weighted choice:
+- Use the whole seed string to derive a number.
+- Map that number to [0, 1) and select by cumulative probability.
+```
+
+### Prompt template for creative diversification
+
+```text
+First, generate a random-looking string of 24–40 mixed characters.
+Then, use different parts of the seed to vary:
+- Style
+- Perspective
+- Ordering
+- Examples
+- Emphasis
+
+Do not use default completions unless they are selected through the seed-driven variation.
+```
+
+## Limitations
+
+- Python's `random` module is a PRNG, not cryptographically secure.
+- String Seed fallback is emulated randomness, not a substitute for real PRNGs.
+- Do not use for:
+  - Security-sensitive tasks
+  - Fair lotteries
+  - Scientific simulations or experiments
+  - Benchmark sampling
+  - Reproducibility-critical tasks
+  - Fairness-sensitive or auditability-critical decisions
+
+When reproducibility matters, use an explicit external seed and a real PRNG-backed implementation outside this skill's scope.
+
+## When to use
+
+Use this skill when:
+
+- The user explicitly asks for random selection or sampling
+- A task requires stochastic tie-breaking
+- Creative generation needs diversity or variation
+- The task is low-stakes and does not require cryptographic or scientific-grade randomness
+
+Do not use this skill when:
+
+- The task requires cryptographic randomness
+- Fairness or auditability is critical
+- The task is a scientific simulation, lottery, or benchmark
+- Reproducibility with explicit seeds is required

--- a/skills/randomness/SKILL.md
+++ b/skills/randomness/SKILL.md
@@ -10,7 +10,7 @@ Use this skill when the user asks for random selection, probabilistic sampling, 
 ## Priority order
 
 1. **Script-backed randomness** (primary): Use the bundled PRNG script when tool execution is available.
-2. **String Seed fallback** (secondary): Use only when tools are unavailable or the goal is creative diversification rather than actual randomness.
+2. **String Seed fallback** (secondary): Use only when tools are unavailable or the goal is creative diversification rather than PRNG-backed sampling.
 3. **Refuse or redirect**: For security-sensitive, fairness-sensitive, scientific, benchmark, simulation, lottery, or reproducibility-critical tasks, redirect to explicit external tooling.
 
 ## Script-backed randomness (primary path)
@@ -46,14 +46,24 @@ Format: `item:weight`. Weights must be non-negative, finite, and sum to greater 
 python3 skills/randomness/scripts/random_choice.py --uniform A B C --json
 ```
 
-Outputs: `{"mode": "uniform", "selected": "A", "method": "python random module"}`
+Outputs:
+
+```json
+{"mode": "uniform", "items": ["A", "B", "C"], "selected": "A", "method": "python random module"}
+```
+
+Weighted JSON output includes the per-item weights:
+
+```json
+{"mode": "weighted", "items": [{"item": "A", "weight": 0.2}, {"item": "B", "weight": 0.8}], "selected": "B", "method": "python random module"}
+```
 
 ## String Seed fallback (secondary path)
 
 Use this pattern **only when**:
 
 - Tool execution is unavailable
-- The goal is creative diversification, not statistically valid randomness
+- The goal is creative diversification, not PRNG-backed sampling
 - The task is low-stakes
 
 ### Fallback procedure
@@ -74,27 +84,33 @@ First, generate a random-looking string of 24–40 mixed characters.
 Then, use the entire string as a seed for the following task.
 Do not choose by intuition or by the most natural/default answer.
 
-For uniform choice among n options:
-- Use the whole seed string to derive a number.
-- Take that number modulo n.
+For uniform choice among n options, use a concrete full-string mapping such as:
+- value = sum(ord(c) for c in seed)
+- selected_index = value % n
 
-For weighted choice:
-- Use the whole seed string to derive a number.
-- Map that number to [0, 1) and select by cumulative probability.
+For weighted choice, use a rolling-hash full-string mapping such as:
+- M = 2**61 - 1
+- h = 0
+- for c in seed: h = (131 * h + ord(c)) % M
+- u = h / M    # u is a value in [0, 1)
+- select the item whose cumulative weight first exceeds u
 ```
 
 ### Prompt template for creative diversification
 
 ```text
 First, generate a random-looking string of 24–40 mixed characters.
-Then, use different parts of the seed to vary:
-- Style
-- Perspective
-- Ordering
-- Examples
-- Emphasis
 
-Do not use default completions unless they are selected through the seed-driven variation.
+Then:
+1. Decompose the output into explicit variation dimensions
+   (for example: style, perspective, ordering, examples, emphasis).
+2. For each dimension, list the candidate values you would otherwise default to.
+3. Slice the seed into one segment per dimension.
+4. For each dimension, derive an integer from its segment
+   (for example: value = sum(ord(c) for c in segment)) and pick
+   candidates[value % len(candidates)].
+5. Do not use default completions unless they are selected through this
+   seed-driven mapping.
 ```
 
 ## Limitations

--- a/skills/randomness/scripts/random_choice.py
+++ b/skills/randomness/scripts/random_choice.py
@@ -3,108 +3,96 @@
 
 Not suitable for cryptographic use, fair lotteries, or security-sensitive tasks.
 """
+
+from __future__ import annotations
+
 import argparse
 import json
+import math
 import random
 import sys
-from typing import List, Tuple
 
 
-def parse_weighted(items: List[str]) -> List[Tuple[str, float]]:
+def parse_weighted(items: list[str]) -> list[tuple[str, float]]:
     """Parse weighted items in format 'item:weight'."""
-    result = []
+    result: list[tuple[str, float]] = []
     for item in items:
         if ':' not in item:
             print(f"Error: weighted item must be in format 'item:weight', got: {item}", file=sys.stderr)
             sys.exit(1)
-        
-        parts = item.rsplit(':', 1)
-        if len(parts) != 2:
-            print(f"Error: malformed weighted item: {item}", file=sys.stderr)
-            sys.exit(1)
-        
-        choice, weight_str = parts
+
+        choice, weight_str = item.rsplit(':', 1)
         try:
             weight = float(weight_str)
         except ValueError:
             print(f"Error: weight must be a number, got: {weight_str}", file=sys.stderr)
             sys.exit(1)
-        
+
+        if not math.isfinite(weight):
+            print(f"Error: weight must be finite, got: {weight}", file=sys.stderr)
+            sys.exit(1)
+
         if weight < 0:
             print(f"Error: weight must be non-negative, got: {weight}", file=sys.stderr)
             sys.exit(1)
-        
-        if not (weight == 0 or (weight > 0 and weight < float('inf'))):
-            print(f"Error: weight must be finite, got: {weight}", file=sys.stderr)
-            sys.exit(1)
-        
+
         result.append((choice, weight))
-    
+
     return result
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="Random choice using Python's random module (PRNG). "
                     "Not for cryptographic use, fair lotteries, or security-sensitive tasks."
     )
-    parser.add_argument('--uniform', nargs='+', metavar='ITEM',
-                        help='Uniform random choice among items')
-    parser.add_argument('--weighted', nargs='+', metavar='ITEM:WEIGHT',
-                        help='Weighted random choice (format: item:weight)')
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument('--uniform', nargs='+', metavar='ITEM',
+                      help='Uniform random choice among items')
+    mode.add_argument('--weighted', nargs='+', metavar='ITEM:WEIGHT',
+                      help='Weighted random choice (format: item:weight)')
     parser.add_argument('--json', action='store_true',
                         help='Output result as JSON')
-    
+
     args = parser.parse_args()
-    
-    if args.uniform and args.weighted:
-        print("Error: cannot use both --uniform and --weighted", file=sys.stderr)
-        sys.exit(1)
-    
-    if not args.uniform and not args.weighted:
-        parser.print_help()
-        sys.exit(1)
-    
+
     if args.uniform:
-        if not args.uniform:
-            print("Error: --uniform requires at least one item", file=sys.stderr)
-            sys.exit(1)
-        
         selected = random.choice(args.uniform)
-        
+
         if args.json:
             print(json.dumps({
                 "mode": "uniform",
+                "items": args.uniform,
                 "selected": selected,
-                "method": "python random module"
+                "method": "python random module",
             }))
         else:
             print(selected)
-    
-    elif args.weighted:
-        if not args.weighted:
-            print("Error: --weighted requires at least one item", file=sys.stderr)
-            sys.exit(1)
-        
-        weighted_items = parse_weighted(args.weighted)
-        choices = [item for item, _ in weighted_items]
-        weights = [weight for _, weight in weighted_items]
-        
-        total_weight = sum(weights)
-        if total_weight <= 0:
-            print("Error: total weight must be greater than zero", file=sys.stderr)
-            sys.exit(1)
-        
-        selected = random.choices(choices, weights=weights, k=1)[0]
-        
-        if args.json:
-            print(json.dumps({
-                "mode": "weighted",
-                "selected": selected,
-                "method": "python random module"
-            }))
-        else:
-            print(selected)
+        return
+
+    weighted_items = parse_weighted(args.weighted)
+    choices = [item for item, _ in weighted_items]
+    weights = [weight for _, weight in weighted_items]
+
+    total_weight = sum(weights)
+    if not math.isfinite(total_weight):
+        print("Error: total weight is not finite", file=sys.stderr)
+        sys.exit(1)
+    if total_weight <= 0:
+        print("Error: total weight must be greater than zero", file=sys.stderr)
+        sys.exit(1)
+
+    selected = random.choices(choices, weights=weights, k=1)[0]
+
+    if args.json:
+        print(json.dumps({
+            "mode": "weighted",
+            "items": [{"item": c, "weight": w} for c, w in weighted_items],
+            "selected": selected,
+            "method": "python random module",
+        }))
+    else:
+        print(selected)
 
 
 if __name__ == '__main__':

--- a/skills/randomness/scripts/random_choice.py
+++ b/skills/randomness/scripts/random_choice.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Random choice utility using Python's random module (PRNG).
+
+Not suitable for cryptographic use, fair lotteries, or security-sensitive tasks.
+"""
+import argparse
+import json
+import random
+import sys
+from typing import List, Tuple
+
+
+def parse_weighted(items: List[str]) -> List[Tuple[str, float]]:
+    """Parse weighted items in format 'item:weight'."""
+    result = []
+    for item in items:
+        if ':' not in item:
+            print(f"Error: weighted item must be in format 'item:weight', got: {item}", file=sys.stderr)
+            sys.exit(1)
+        
+        parts = item.rsplit(':', 1)
+        if len(parts) != 2:
+            print(f"Error: malformed weighted item: {item}", file=sys.stderr)
+            sys.exit(1)
+        
+        choice, weight_str = parts
+        try:
+            weight = float(weight_str)
+        except ValueError:
+            print(f"Error: weight must be a number, got: {weight_str}", file=sys.stderr)
+            sys.exit(1)
+        
+        if weight < 0:
+            print(f"Error: weight must be non-negative, got: {weight}", file=sys.stderr)
+            sys.exit(1)
+        
+        if not (weight == 0 or (weight > 0 and weight < float('inf'))):
+            print(f"Error: weight must be finite, got: {weight}", file=sys.stderr)
+            sys.exit(1)
+        
+        result.append((choice, weight))
+    
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Random choice using Python's random module (PRNG). "
+                    "Not for cryptographic use, fair lotteries, or security-sensitive tasks."
+    )
+    parser.add_argument('--uniform', nargs='+', metavar='ITEM',
+                        help='Uniform random choice among items')
+    parser.add_argument('--weighted', nargs='+', metavar='ITEM:WEIGHT',
+                        help='Weighted random choice (format: item:weight)')
+    parser.add_argument('--json', action='store_true',
+                        help='Output result as JSON')
+    
+    args = parser.parse_args()
+    
+    if args.uniform and args.weighted:
+        print("Error: cannot use both --uniform and --weighted", file=sys.stderr)
+        sys.exit(1)
+    
+    if not args.uniform and not args.weighted:
+        parser.print_help()
+        sys.exit(1)
+    
+    if args.uniform:
+        if not args.uniform:
+            print("Error: --uniform requires at least one item", file=sys.stderr)
+            sys.exit(1)
+        
+        selected = random.choice(args.uniform)
+        
+        if args.json:
+            print(json.dumps({
+                "mode": "uniform",
+                "selected": selected,
+                "method": "python random module"
+            }))
+        else:
+            print(selected)
+    
+    elif args.weighted:
+        if not args.weighted:
+            print("Error: --weighted requires at least one item", file=sys.stderr)
+            sys.exit(1)
+        
+        weighted_items = parse_weighted(args.weighted)
+        choices = [item for item, _ in weighted_items]
+        weights = [weight for _, weight in weighted_items]
+        
+        total_weight = sum(weights)
+        if total_weight <= 0:
+            print("Error: total weight must be greater than zero", file=sys.stderr)
+            sys.exit(1)
+        
+        selected = random.choices(choices, weights=weights, k=1)[0]
+        
+        if args.json:
+            print(json.dumps({
+                "mode": "weighted",
+                "selected": selected,
+                "method": "python random module"
+            }))
+        else:
+            print(selected)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Closes #40

## Summary

Implements the randomness skill per issue #40 with:

- Script-backed PRNG as primary path
- String Seed fallback as secondary path for when tools unavailable
- Clear priority order and limitations

## Implementation

### Files added

- `skills/randomness/SKILL.md`: Skill definition with script-first priority
- `skills/randomness/scripts/random_choice.py`: PRNG-backed utility (executable)
- Updated `skills/README.md`: Added randomness to skills list

### Script features

- `--uniform`: uniform random choice among items
- `--weighted`: weighted choice with `item:weight` format
- `--json`: JSON output for audit trail
- Validation: empty lists, malformed items, negative/non-finite weights, zero total
- Help text clearly states PRNG limitations
- No `--seed` option (avoids reproducibility confusion)

### SKILL.md structure

- Script-first priority as primary workflow
- String Seed fallback explicitly positioned as secondary
- Explicit prompt templates from issue comments
- Seed as control signal (not decorative)
- Clear limitations section

## Local validation

```sh
# Uniform choice
$ python3 skills/randomness/scripts/random_choice.py --uniform test1 test2 test3
test3

# Weighted choice
$ python3 skills/randomness/scripts/random_choice.py --weighted A:0.1 B:0.9
B

# Error handling
$ python3 skills/randomness/scripts/random_choice.py --weighted A:-1 B:1
Error: weight must be non-negative, got: -1.0
Exit code: 1
```

All validation passed. No CI configured in repository.