### PR TITLE
warn and continue on non-symlink conflict

### DIFF
--- a/scripts/install_skill.py
+++ b/scripts/install_skill.py
@@ -114,10 +114,10 @@ def remove_existing(target_dir: Path, force: bool) -> None:
         return
 
     if not force:
-            raise ConflictError(
-                f"Refusing to replace existing non-symlink target: {target_dir}. "
-                "Use --force to replace it."
-            )
+        raise ConflictError(
+            f"Refusing to replace existing non-symlink target: {target_dir}. "
+            "Use --force to replace it."
+        )
 
     if target_dir.is_dir():
         shutil.rmtree(target_dir)

--- a/scripts/install_skill.py
+++ b/scripts/install_skill.py
@@ -191,17 +191,25 @@ def main() -> int:
     workspace_root = Path(args.workspace_root).expanduser()
     base_dirs = target_base_dirs(workspace_root, args.target)
 
+    warnings: List[str] = []
     for skill_name in skill_names(skills_dir, args.skill_name):
         source_dir = skills_dir / skill_name
         for target_base_dir in base_dirs:
-            install_skill(
-                skill_name,
-                source_dir,
-                target_base_dir,
-                copy=args.copy,
-                force=args.force,
-            )
+            try:
+                install_skill(
+                    skill_name,
+                    source_dir,
+                    target_base_dir,
+                    copy=args.copy,
+                    force=args.force,
+                )
+            except InstallError as error:
+                msg = f"warning: {error}"
+                print(msg, file=sys.stderr)
+                warnings.append(msg)
 
+    if warnings:
+        return 2
     return 0
 
 

--- a/scripts/install_skill.py
+++ b/scripts/install_skill.py
@@ -29,6 +29,10 @@ class InstallError(Exception):
     pass
 
 
+class ConflictError(InstallError):
+    """Raised when a non-symlink target exists and --force was not given."""
+
+
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     argv = sys.argv[1:] if argv is None else argv
     parser = argparse.ArgumentParser(
@@ -110,10 +114,10 @@ def remove_existing(target_dir: Path, force: bool) -> None:
         return
 
     if not force:
-        raise InstallError(
-            f"Refusing to replace existing non-symlink target: {target_dir}. "
-            "Use --force to replace it."
-        )
+            raise ConflictError(
+                f"Refusing to replace existing non-symlink target: {target_dir}. "
+                "Use --force to replace it."
+            )
 
     if target_dir.is_dir():
         shutil.rmtree(target_dir)
@@ -191,7 +195,7 @@ def main() -> int:
     workspace_root = Path(args.workspace_root).expanduser()
     base_dirs = target_base_dirs(workspace_root, args.target)
 
-    warnings: List[str] = []
+    skipped = 0
     for skill_name in skill_names(skills_dir, args.skill_name):
         source_dir = skills_dir / skill_name
         for target_base_dir in base_dirs:
@@ -203,12 +207,11 @@ def main() -> int:
                     copy=args.copy,
                     force=args.force,
                 )
-            except InstallError as error:
-                msg = f"warning: {error}"
-                print(msg, file=sys.stderr)
-                warnings.append(msg)
+            except ConflictError as error:
+                print(f"warning: {error}", file=sys.stderr)
+                skipped += 1
 
-    if warnings:
+    if skipped:
         return 2
     return 0
 


### PR DESCRIPTION
Closes #42

## Changes

In `install_skill.py`, introduce `ConflictError(InstallError)` for the non-symlink conflict case in `remove_existing`. Catch only `ConflictError` in the main loop to print a `warning:` to stderr and continue. All other `InstallError`s (missing skill, permission errors, etc.) remain fatal.

Exit code `2` when any skill was skipped due to a conflict; `0` for clean success.

## Validation

```
python3 -c "import ast; ast.parse(open('scripts/install_skill.py').read()); print('syntax OK')"
# syntax OK

# Simulated conflict: pre-existing real dir for 'triage'
python3 scripts/install_skill.py all claude <tmpdir>
# warning: Refusing to replace existing non-symlink target: ...triage. Use --force to replace it.
# Linked deslop-history -> ...
# ... (all other skills installed)
# exit: 2
```