### PR TITLE
git-prune-worktrees: detect squash/rebase-merged branches via GitHub PR

### DIFF
--- a/skills/git-prune-worktrees/SKILL.md
+++ b/skills/git-prune-worktrees/SKILL.md
@@ -27,8 +27,9 @@ The script is the source of truth for cleanup eligibility. Do not duplicate its 
 ## Common options
 
 - `--base origin/main`: merge target for strict reachability checks.
-- `--remote origin`: remote used for fetch/prune.
+- `--remote origin`: remote used for fetch/prune and for GitHub PR detection.
 - `--no-fetch`: skip fetch/prune when network access is unavailable or not approved.
+- `--no-detect-pr-merged`: disable GitHub PR-merged detection (default: enabled when `gh` is on PATH and the remote points to GitHub).
 - `--switch-base`: with `--yes`, switch away from a merged current branch before deleting it.
 - `--include-pattern <glob>`: only consider matching local branch names.
 - `--exclude-pattern <glob>`: protect matching local branch names. Exclude wins over include.
@@ -37,12 +38,19 @@ The script is the source of truth for cleanup eligibility. Do not duplicate its 
 ## Approval and failure handling
 
 - Dry-run mode uses `git fetch --dry-run --prune`; it should not mutate refs.
-- `--yes` may run `git fetch --prune`, `git worktree remove`, `git switch`, `git merge --ff-only`, `git branch -d`, and `git worktree prune`.
+- `--yes` may run `git fetch --prune`, `git worktree remove`, `git switch`, `git merge --ff-only`, `git branch -d`, `git branch -D` (only for PR-verified branches; see Safety model), and `git worktree prune`.
 - If network access or `.git` mutation is blocked by the environment, use the environment's normal approval path. Do not bypass Git by deleting files manually.
-- Never force cleanup. The script must not use `git worktree remove --force` or `git branch -D`.
+- The script must not use `git worktree remove --force`.
 
 ## Safety model
 
-The first version uses strict Git reachability only. Branches merged by squash, rebase, or cherry-pick are manual cleanup cases.
+A branch is considered merged when either condition holds:
+
+1. **Reachability**: the branch tip is reachable from `--base` (true merge or fast-forward). Action uses `git branch -d` and reports `reason: merged_branch`.
+2. **PR-verified**: a merged GitHub PR exists with `head = <branch>` and `base = <base>` (covers squash and rebase merges). Action uses `git branch -D` and reports `reason: merged_branch_via_pr` with `detail: merged via PR #<N>` recording the evidence.
+
+`git branch -D` is permitted only for case 2; the recorded PR# is required as the audit trail. Cherry-picks without an associated merged PR remain manual cleanup cases.
+
+PR detection is enabled by default. It is automatically and silently skipped when `gh` is not on PATH or when the selected remote URL does not contain `github.com`. Use `--no-detect-pr-merged` to disable it explicitly. Per-branch `gh` failures are reported as `pr_check_failed` errors but do not abort the run.
 
 The script skips dirty, locked, detached, missing-path, unmerged, protected, current, and checked-out branches or worktrees with explicit reasons. Treat skipped items as requiring manual review or a later rerun after the blocking condition is resolved.

--- a/skills/git-prune-worktrees/SKILL.md
+++ b/skills/git-prune-worktrees/SKILL.md
@@ -47,9 +47,9 @@ The script is the source of truth for cleanup eligibility. Do not duplicate its 
 A branch is considered merged when either condition holds:
 
 1. **Reachability**: the branch tip is reachable from `--base` (true merge or fast-forward). Action uses `git branch -d` and reports `reason: merged_branch`.
-2. **PR-verified**: a merged GitHub PR exists with `head = <branch>` and `base = <base>` (covers squash and rebase merges). Action uses `git branch -D` and reports `reason: merged_branch_via_pr` with `detail: merged via PR #<N>` recording the evidence.
+2. **PR-verified**: a merged GitHub PR exists with `head = <branch>` and `base = <base>`, **and** the local branch tip OID equals the PR's recorded `headRefOid` (covers squash and rebase merges). Action uses `git branch -D` and reports `reason: merged_branch_via_pr` with `detail: merged via PR #<N>` recording the evidence.
 
-`git branch -D` is permitted only for case 2; the recorded PR# is required as the audit trail. Cherry-picks without an associated merged PR remain manual cleanup cases.
+`git branch -D` is permitted only for case 2; the recorded PR# is required as the audit trail. The headRefOid match guards against branch-name reuse: if a branch was deleted and recreated (or extended with new local commits) after a PR with the same name was merged, the local tip will not match the merged PR's head and the branch is treated as unmerged. Cherry-picks without an associated merged PR remain manual cleanup cases.
 
 PR detection is enabled by default. It is automatically and silently skipped when `gh` is not on PATH or when the selected remote URL does not contain `github.com`. Use `--no-detect-pr-merged` to disable it explicitly. Per-branch `gh` failures are reported as `pr_check_failed` errors but do not abort the run.
 

--- a/skills/git-prune-worktrees/scripts/git_prune_worktrees.py
+++ b/skills/git-prune-worktrees/scripts/git_prune_worktrees.py
@@ -130,6 +130,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--json", action="store_true", help="print one JSON object")
     parser.add_argument("--no-fetch", action="store_true", help="skip fetch/prune")
+    parser.add_argument(
+        "--no-detect-pr-merged",
+        action="store_true",
+        help="disable GitHub PR-merged detection (default: enabled when gh and a GitHub remote are available)",
+    )
     return parser.parse_args(argv)
 
 
@@ -284,6 +289,97 @@ def is_merged(repo: str, branch_info: dict[str, str], base_commit: str) -> tuple
     return False, error_record("merge_check_failed", result.command, result.stderr, branch_info["name"])
 
 
+def parse_github_url(url: str) -> tuple[str, str] | None:
+    if "github.com" not in url:
+        return None
+    path: str | None = None
+    for prefix in (
+        "https://github.com/",
+        "http://github.com/",
+        "ssh://git@github.com/",
+        "git@github.com:",
+    ):
+        if url.startswith(prefix):
+            path = url[len(prefix):]
+            break
+    if path is None:
+        return None
+    if path.endswith(".git"):
+        path = path[:-4]
+    parts = path.strip("/").split("/")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        return None
+    return parts[0], parts[1]
+
+
+def discover_github_repo(repo: str, remote: str) -> tuple[str, str] | None:
+    result = run_git(["remote", "get-url", remote], repo)
+    if result.returncode != 0:
+        return None
+    return parse_github_url(result.stdout.strip())
+
+
+def gh_available() -> bool:
+    try:
+        completed = subprocess.run(
+            ["gh", "--version"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return False
+    return completed.returncode == 0
+
+
+def base_branch_name(base: str) -> str:
+    if base.startswith("refs/heads/"):
+        return base.removeprefix("refs/heads/")
+    _remote, branch = base_remote(base)
+    return branch or base
+
+
+def pr_merged_via_gh(
+    repo: str,
+    owner: str,
+    name: str,
+    branch: str,
+    base: str,
+) -> tuple[int | None, dict[str, Any] | None]:
+    command = [
+        "gh", "pr", "list",
+        "--repo", f"{owner}/{name}",
+        "--state", "merged",
+        "--head", branch,
+        "--base", base,
+        "--json", "number",
+        "--limit", "1",
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=repo,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            check=False,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        return None, error_record("pr_check_failed", command, str(exc), branch)
+    if completed.returncode != 0:
+        return None, error_record("pr_check_failed", command, completed.stderr, branch)
+    try:
+        items = json.loads(completed.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        return None, error_record("pr_check_failed", command, str(exc), branch)
+    if not items:
+        return None, None
+    number = items[0].get("number") if isinstance(items[0], dict) else None
+    if not isinstance(number, int):
+        return None, None
+    return number, None
+
+
 def pattern_matches(branch: str, patterns: list[str]) -> bool:
     return any(fnmatch.fnmatchcase(branch, pattern) for pattern in patterns)
 
@@ -360,17 +456,41 @@ def build_plan(
     initial_branch: str | None,
     branches: dict[str, dict[str, str]],
     worktrees: list[dict[str, Any]],
+    remote: str,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     actions: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
     merged: dict[str, bool] = {}
+    pr_merged_numbers: dict[str, int] = {}
 
     for branch, info in branches.items():
         branch_merged, error = is_merged(repo, info, base_commit)
         merged[branch] = branch_merged
         if error:
             errors.append(error)
+
+    detect_pr = not args.no_detect_pr_merged and gh_available()
+    gh_repo = discover_github_repo(repo, remote) if detect_pr else None
+    if gh_repo is not None:
+        gh_owner, gh_name = gh_repo
+        pr_base = base_branch_name(args.base)
+        for branch, info in branches.items():
+            if merged.get(branch, False):
+                continue
+            if filter_reason(branch, args.include_pattern, args.exclude_pattern):
+                continue
+            if protected_reason(
+                branch, initial_branch, local_base_branch, args.switch_base, args.exclude_pattern,
+            ):
+                continue
+            number, pr_error = pr_merged_via_gh(repo, gh_owner, gh_name, branch, pr_base)
+            if pr_error:
+                errors.append(pr_error)
+                continue
+            if number is not None:
+                merged[branch] = True
+                pr_merged_numbers[branch] = number
 
     primary_path = worktrees[0]["path"] if worktrees else None
     linked_worktrees = worktrees[1:] if worktrees else []
@@ -426,13 +546,20 @@ def build_plan(
         if dirty:
             skipped.append(skip_record("worktree", path, branch, "dirty"))
             continue
+        if branch in pr_merged_numbers:
+            wt_reason = "merged_clean_worktree_via_pr"
+            wt_detail = f"merged via PR #{pr_merged_numbers[branch]}"
+        else:
+            wt_reason = "merged_clean_worktree"
+            wt_detail = None
         actions.append(
             action_record(
                 "remove_worktree",
                 path,
                 branch,
                 [["git", "worktree", "remove", path]],
-                "merged_clean_worktree",
+                wt_reason,
+                wt_detail,
             )
         )
         remove_worktree_branches.add(branch)
@@ -498,13 +625,22 @@ def build_plan(
                 )
             continue
 
+        if branch in pr_merged_numbers:
+            delete_command = ["git", "branch", "-D", branch]
+            delete_reason = "merged_branch_via_pr"
+            delete_detail = f"merged via PR #{pr_merged_numbers[branch]}"
+        else:
+            delete_command = ["git", "branch", "-d", branch]
+            delete_reason = "merged_branch"
+            delete_detail = None
         actions.append(
             action_record(
                 "delete_branch",
                 branch,
                 branch,
-                [["git", "branch", "-d", branch]],
-                "merged_branch",
+                [delete_command],
+                delete_reason,
+                delete_detail,
             )
         )
 
@@ -777,6 +913,7 @@ def main(argv: list[str] | None = None) -> int:
         initial_branch,
         branches,
         worktrees,
+        remote,
     )
     errors = [*discovery_errors, *plan_errors]
 

--- a/skills/git-prune-worktrees/scripts/git_prune_worktrees.py
+++ b/skills/git-prune-worktrees/scripts/git_prune_worktrees.py
@@ -344,6 +344,7 @@ def pr_merged_via_gh(
     owner: str,
     name: str,
     branch: str,
+    branch_oid: str,
     base: str,
 ) -> tuple[int | None, dict[str, Any] | None]:
     command = [
@@ -352,8 +353,8 @@ def pr_merged_via_gh(
         "--state", "merged",
         "--head", branch,
         "--base", base,
-        "--json", "number",
-        "--limit", "1",
+        "--json", "number,headRefOid",
+        "--limit", "20",
     ]
     try:
         completed = subprocess.run(
@@ -372,12 +373,19 @@ def pr_merged_via_gh(
         items = json.loads(completed.stdout or "[]")
     except json.JSONDecodeError as exc:
         return None, error_record("pr_check_failed", command, str(exc), branch)
-    if not items:
-        return None, None
-    number = items[0].get("number") if isinstance(items[0], dict) else None
-    if not isinstance(number, int):
-        return None, None
-    return number, None
+    # Require the local branch tip to match the PR's recorded head SHA. The
+    # --head filter is a name-only match, so without this check a reused branch
+    # name (old PR merged, new local commits added) would falsely verify and
+    # the subsequent `git branch -D` would destroy the new commits.
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if item.get("headRefOid") != branch_oid:
+            continue
+        number = item.get("number")
+        if isinstance(number, int):
+            return number, None
+    return None, None
 
 
 def pattern_matches(branch: str, patterns: list[str]) -> bool:
@@ -474,7 +482,9 @@ def build_plan(
     gh_repo = discover_github_repo(repo, remote) if detect_pr else None
     if gh_repo is not None:
         gh_owner, gh_name = gh_repo
-        pr_base = base_branch_name(args.base)
+        # Prefer the resolved local base branch (preserves slashes such as
+        # `release/foo`) over heuristic stripping of `--base`.
+        pr_base = local_base_branch or base_branch_name(args.base)
         for branch, info in branches.items():
             if merged.get(branch, False):
                 continue
@@ -484,7 +494,9 @@ def build_plan(
                 branch, initial_branch, local_base_branch, args.switch_base, args.exclude_pattern,
             ):
                 continue
-            number, pr_error = pr_merged_via_gh(repo, gh_owner, gh_name, branch, pr_base)
+            number, pr_error = pr_merged_via_gh(
+                repo, gh_owner, gh_name, branch, info["object"], pr_base,
+            )
             if pr_error:
                 errors.append(pr_error)
                 continue

--- a/skills/git-prune-worktrees/scripts/test_git_prune_worktrees.py
+++ b/skills/git-prune-worktrees/scripts/test_git_prune_worktrees.py
@@ -17,19 +17,30 @@ from pathlib import Path
 SCRIPT = Path(__file__).with_name("git_prune_worktrees.py")
 
 
-def install_fake_gh(root: Path, responses: dict[str, list[dict[str, int]]] | None = None, *, fail: bool = False) -> Path:
+def install_fake_gh(
+    root: Path,
+    responses: dict[tuple[str, str], list[dict[str, object]]] | None = None,
+    *,
+    fail: bool = False,
+) -> Path:
     """Create a fake `gh` executable in a fresh dir and return that dir.
 
-    `responses` maps head-branch name to the JSON array `gh pr list ... --json number` should return.
+    `responses` maps (head-branch, base-branch) to the JSON array
+    `gh pr list ... --json number,headRefOid` should return.
     `fail=True` makes every non-version invocation exit nonzero (simulates auth failure).
     """
     bin_dir = root / "fake-bin"
     bin_dir.mkdir(parents=True, exist_ok=True)
     data_dir = root / "fake-gh-data"
     data_dir.mkdir(parents=True, exist_ok=True)
+    index: dict[str, str] = {}
     if responses is not None:
-        for branch, payload in responses.items():
-            (data_dir / f"{branch}.json").write_text(json.dumps(payload), encoding="utf-8")
+        for i, ((head, base), payload) in enumerate(responses.items()):
+            data_path = data_dir / f"resp-{i}.json"
+            data_path.write_text(json.dumps(payload), encoding="utf-8")
+            index[f"{head}\0{base}"] = str(data_path)
+    index_path = data_dir / "index.json"
+    index_path.write_text(json.dumps(index), encoding="utf-8")
     script = bin_dir / "gh"
     script.write_text(
         f"""#!/usr/bin/env python3
@@ -41,16 +52,19 @@ if args[:1] == ["--version"]:
 if {fail!r}:
     sys.stderr.write("fake gh: simulated failure\\n")
     sys.exit(1)
-head = ""
+head = base = ""
 i = 0
 while i < len(args):
     if args[i] == "--head" and i + 1 < len(args):
         head = args[i + 1]
-        break
+    elif args[i] == "--base" and i + 1 < len(args):
+        base = args[i + 1]
     i += 1
-data_dir = {str(data_dir)!r}
-path = os.path.join(data_dir, head + ".json")
-if os.path.exists(path):
+with open({str(index_path)!r}) as fh:
+    index = json.load(fh)
+key = head + "\\x00" + base
+path = index.get(key)
+if path and os.path.exists(path):
     with open(path) as fh:
         sys.stdout.write(fh.read())
 else:
@@ -61,6 +75,10 @@ sys.exit(0)
     )
     script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     return bin_dir
+
+
+def branch_oid(repo: Path, branch: str) -> str:
+    return git(repo, "rev-parse", branch).stdout.strip()
 
 
 def env_without_real_gh(extra_bin: Path | None = None) -> dict[str, str]:
@@ -280,19 +298,22 @@ class GitPruneWorktreesTests(unittest.TestCase):
             self.assertEqual(data["remote"], "origin")
             self.assertEqual(data["base"]["local_branch"], "release/foo")  # type: ignore[index]
 
-    def _setup_squash_fixture(self, root: Path, branch: str = "issue-99-foo") -> RepoFixture:
+    def _setup_squash_fixture(self, root: Path, branch: str = "issue-99-foo") -> tuple[RepoFixture, str]:
         fixture = RepoFixture.create(root)
         make_squash_merged_branch(fixture.repo, branch)
+        oid = branch_oid(fixture.repo, branch)
         # Point origin at a GitHub-style URL so PR detection activates.
         # Fetch is unreachable, so tests must pass --no-fetch.
         git(fixture.repo, "remote", "set-url", "origin", "git@github.com:fake/repo.git")
-        return fixture
+        return fixture, oid
 
     def test_pr_merged_branch_force_deleted_with_pr_detail(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            fixture = self._setup_squash_fixture(root)
-            bin_dir = install_fake_gh(root, {"issue-99-foo": [{"number": 99}]})
+            fixture, oid = self._setup_squash_fixture(root)
+            bin_dir = install_fake_gh(
+                root, {("issue-99-foo", "main"): [{"number": 99, "headRefOid": oid}]},
+            )
             env = env_without_real_gh(bin_dir)
 
             result, data = self.run_script(
@@ -310,8 +331,10 @@ class GitPruneWorktreesTests(unittest.TestCase):
     def test_no_detect_pr_merged_disables_detection(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            fixture = self._setup_squash_fixture(root)
-            bin_dir = install_fake_gh(root, {"issue-99-foo": [{"number": 99}]})
+            fixture, oid = self._setup_squash_fixture(root)
+            bin_dir = install_fake_gh(
+                root, {("issue-99-foo", "main"): [{"number": 99, "headRefOid": oid}]},
+            )
             env = env_without_real_gh(bin_dir)
 
             result, data = self.run_script(
@@ -326,7 +349,7 @@ class GitPruneWorktreesTests(unittest.TestCase):
     def test_gh_missing_silently_falls_back(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            fixture = self._setup_squash_fixture(root)
+            fixture, _oid = self._setup_squash_fixture(root)
             env = env_without_real_gh(None)
 
             result, data = self.run_script(
@@ -343,8 +366,11 @@ class GitPruneWorktreesTests(unittest.TestCase):
             root = Path(tmp)
             fixture = RepoFixture.create(root)
             make_squash_merged_branch(fixture.repo, "issue-99-foo")
+            oid = branch_oid(fixture.repo, "issue-99-foo")
             # Origin already points at the local bare repo (not github.com).
-            bin_dir = install_fake_gh(root, {"issue-99-foo": [{"number": 99}]})
+            bin_dir = install_fake_gh(
+                root, {("issue-99-foo", "main"): [{"number": 99, "headRefOid": oid}]},
+            )
             env = env_without_real_gh(bin_dir)
 
             result, data = self.run_script(
@@ -359,7 +385,7 @@ class GitPruneWorktreesTests(unittest.TestCase):
     def test_gh_failure_recorded_but_does_not_abort(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            fixture = self._setup_squash_fixture(root)
+            fixture, _oid = self._setup_squash_fixture(root)
             # Also create a normally-merged branch that should still be deleted.
             make_merged_branch(fixture.repo, "merged-delete")
             bin_dir = install_fake_gh(root, fail=True)
@@ -394,6 +420,75 @@ class GitPruneWorktreesTests(unittest.TestCase):
             self.assertEqual(planned[0]["reason"], "merged_branch")
             self.assertEqual(planned[0]["command"], ["git", "branch", "-d", "true-merged"])
             self.assertNotIn("detail", planned[0])
+
+    def test_pr_head_oid_mismatch_blocks_force_delete(self) -> None:
+        """A merged PR for the same branch name must not authorize deleting a
+        branch whose tip has diverged (e.g. branch reused after the original PR
+        merged). Without this guard, `git branch -D` would destroy unmerged work.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture, old_oid = self._setup_squash_fixture(root)
+            # Add a new commit to the branch so its tip diverges from the merged PR's headRefOid.
+            git(fixture.repo, "switch", "issue-99-foo")
+            make_commit(fixture.repo, "extra")
+            git(fixture.repo, "switch", "main")
+            new_oid = branch_oid(fixture.repo, "issue-99-foo")
+            self.assertNotEqual(old_oid, new_oid)
+
+            bin_dir = install_fake_gh(
+                root, {("issue-99-foo", "main"): [{"number": 99, "headRefOid": old_oid}]},
+            )
+            env = env_without_real_gh(bin_dir)
+
+            result, data = self.run_script(
+                fixture.repo, "--base", "main", "--no-fetch", "--yes", env=env,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            self.assertTrue(branch_exists(fixture.repo, "issue-99-foo"))
+            reasons = {item["reason"] for item in data["skipped"] if item["branch"] == "issue-99-foo"}  # type: ignore[index]
+            self.assertEqual(reasons, {"unmerged"})
+
+    def test_local_slash_base_branch_preserved_in_pr_query(self) -> None:
+        """When --base is a local branch like `release/foo`, the PR query must
+        use the full name; otherwise PRs get filtered against the wrong base
+        and a force-delete based on a same-name PR could destroy work.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = RepoFixture.create(root)
+            git(fixture.repo, "branch", "release/foo", "main")
+            # Create a squash-merged branch off `release/foo`.
+            git(fixture.repo, "switch", "-c", "issue-50-bar", "release/foo")
+            make_commit(fixture.repo, "issue-50-bar")
+            git(fixture.repo, "switch", "release/foo")
+            write(fixture.repo / "issue-50-bar.txt", "issue-50-bar")
+            git(fixture.repo, "add", "issue-50-bar.txt")
+            git(fixture.repo, "commit", "-m", "squash issue-50-bar")
+            git(fixture.repo, "switch", "main")
+            oid = branch_oid(fixture.repo, "issue-50-bar")
+            git(fixture.repo, "remote", "set-url", "origin", "git@github.com:fake/repo.git")
+            # Fake gh only returns the PR when queried with base=release/foo (full name).
+            # If the script truncated the base to `foo`, the lookup misses → branch left alone.
+            bin_dir = install_fake_gh(
+                root, {("issue-50-bar", "release/foo"): [{"number": 50, "headRefOid": oid}]},
+            )
+            env = env_without_real_gh(bin_dir)
+
+            result, data = self.run_script(
+                fixture.repo, "--base", "release/foo", "--no-fetch", "--yes", env=env,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            self.assertFalse(branch_exists(fixture.repo, "issue-50-bar"))
+            done = [
+                a for a in data["actions"]  # type: ignore[index]
+                if a["status"] == "done" and a["branch"] == "issue-50-bar"
+            ]
+            self.assertEqual(len(done), 1)
+            self.assertEqual(done[0]["reason"], "merged_branch_via_pr")
+            self.assertIn("PR #50", done[0]["detail"])
 
 
 if __name__ == "__main__":

--- a/skills/git-prune-worktrees/scripts/test_git_prune_worktrees.py
+++ b/skills/git-prune-worktrees/scripts/test_git_prune_worktrees.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile
@@ -15,7 +17,69 @@ from pathlib import Path
 SCRIPT = Path(__file__).with_name("git_prune_worktrees.py")
 
 
-def run(command: list[str], cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+def install_fake_gh(root: Path, responses: dict[str, list[dict[str, int]]] | None = None, *, fail: bool = False) -> Path:
+    """Create a fake `gh` executable in a fresh dir and return that dir.
+
+    `responses` maps head-branch name to the JSON array `gh pr list ... --json number` should return.
+    `fail=True` makes every non-version invocation exit nonzero (simulates auth failure).
+    """
+    bin_dir = root / "fake-bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    data_dir = root / "fake-gh-data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    if responses is not None:
+        for branch, payload in responses.items():
+            (data_dir / f"{branch}.json").write_text(json.dumps(payload), encoding="utf-8")
+    script = bin_dir / "gh"
+    script.write_text(
+        f"""#!/usr/bin/env python3
+import json, os, sys
+args = sys.argv[1:]
+if args[:1] == ["--version"]:
+    print("gh fake 0.0.0")
+    sys.exit(0)
+if {fail!r}:
+    sys.stderr.write("fake gh: simulated failure\\n")
+    sys.exit(1)
+head = ""
+i = 0
+while i < len(args):
+    if args[i] == "--head" and i + 1 < len(args):
+        head = args[i + 1]
+        break
+    i += 1
+data_dir = {str(data_dir)!r}
+path = os.path.join(data_dir, head + ".json")
+if os.path.exists(path):
+    with open(path) as fh:
+        sys.stdout.write(fh.read())
+else:
+    sys.stdout.write("[]")
+sys.exit(0)
+""",
+        encoding="utf-8",
+    )
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return bin_dir
+
+
+def env_without_real_gh(extra_bin: Path | None = None) -> dict[str, str]:
+    """Return env with real `gh` removed from PATH; optionally prepend a fake-gh dir."""
+    env = os.environ.copy()
+    parts = env.get("PATH", "").split(os.pathsep)
+    filtered = [p for p in parts if p and not (Path(p) / "gh").exists()]
+    if extra_bin is not None:
+        filtered.insert(0, str(extra_bin))
+    env["PATH"] = os.pathsep.join(filtered)
+    return env
+
+
+def run(
+    command: list[str],
+    cwd: Path | None = None,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
         command,
         cwd=str(cwd) if cwd else None,
@@ -23,6 +87,7 @@ def run(command: list[str], cwd: Path | None = None, check: bool = True) -> subp
         stderr=subprocess.PIPE,
         encoding="utf-8",
         check=False,
+        env=env,
     )
     if check and result.returncode != 0:
         raise AssertionError(
@@ -61,6 +126,19 @@ def make_unmerged_branch(repo: Path, branch: str) -> None:
     git(repo, "switch", "-c", branch, "main")
     make_commit(repo, branch)
     git(repo, "switch", "main")
+
+
+def make_squash_merged_branch(repo: Path, branch: str) -> None:
+    """Simulate a squash-merge: branch tip is not reachable from main, but its
+    content has been applied to main as a separate commit.
+    """
+    git(repo, "switch", "-c", branch, "main")
+    make_commit(repo, branch)
+    git(repo, "switch", "main")
+    # Apply the same content as a fresh commit on main (as squash merge would).
+    write(repo / f"{branch}.txt", branch)
+    git(repo, "add", f"{branch}.txt")
+    git(repo, "commit", "-m", f"squash {branch}")
 
 
 class RepoFixture:
@@ -105,8 +183,14 @@ class RepoFixture:
 
 
 class GitPruneWorktreesTests(unittest.TestCase):
-    def run_script(self, repo: Path, *args: str, check: bool = True) -> tuple[subprocess.CompletedProcess[str], dict[str, object]]:
-        result = run([sys.executable, str(SCRIPT), "--json", *args], cwd=repo, check=check)
+    def run_script(
+        self,
+        repo: Path,
+        *args: str,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> tuple[subprocess.CompletedProcess[str], dict[str, object]]:
+        result = run([sys.executable, str(SCRIPT), "--json", *args], cwd=repo, check=check, env=env)
         data = json.loads(result.stdout)
         return result, data
 
@@ -195,6 +279,121 @@ class GitPruneWorktreesTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0)
             self.assertEqual(data["remote"], "origin")
             self.assertEqual(data["base"]["local_branch"], "release/foo")  # type: ignore[index]
+
+    def _setup_squash_fixture(self, root: Path, branch: str = "issue-99-foo") -> RepoFixture:
+        fixture = RepoFixture.create(root)
+        make_squash_merged_branch(fixture.repo, branch)
+        # Point origin at a GitHub-style URL so PR detection activates.
+        # Fetch is unreachable, so tests must pass --no-fetch.
+        git(fixture.repo, "remote", "set-url", "origin", "git@github.com:fake/repo.git")
+        return fixture
+
+    def test_pr_merged_branch_force_deleted_with_pr_detail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = self._setup_squash_fixture(root)
+            bin_dir = install_fake_gh(root, {"issue-99-foo": [{"number": 99}]})
+            env = env_without_real_gh(bin_dir)
+
+            result, data = self.run_script(
+                fixture.repo, "--base", "main", "--no-fetch", "--yes", env=env,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            self.assertFalse(branch_exists(fixture.repo, "issue-99-foo"))
+            done = [a for a in data["actions"] if a["status"] == "done" and a["type"] == "delete_branch"]  # type: ignore[index]
+            self.assertEqual(len(done), 1)
+            self.assertEqual(done[0]["reason"], "merged_branch_via_pr")
+            self.assertIn("PR #99", done[0]["detail"])
+            self.assertEqual(done[0]["command"], ["git", "branch", "-D", "issue-99-foo"])
+
+    def test_no_detect_pr_merged_disables_detection(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = self._setup_squash_fixture(root)
+            bin_dir = install_fake_gh(root, {"issue-99-foo": [{"number": 99}]})
+            env = env_without_real_gh(bin_dir)
+
+            result, data = self.run_script(
+                fixture.repo, "--base", "main", "--no-fetch", "--no-detect-pr-merged", env=env,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            reasons = {item["reason"] for item in data["skipped"] if item["branch"] == "issue-99-foo"}  # type: ignore[index]
+            self.assertEqual(reasons, {"unmerged"})
+            self.assertTrue(branch_exists(fixture.repo, "issue-99-foo"))
+
+    def test_gh_missing_silently_falls_back(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = self._setup_squash_fixture(root)
+            env = env_without_real_gh(None)
+
+            result, data = self.run_script(
+                fixture.repo, "--base", "main", "--no-fetch", env=env,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(data["errors"], [])
+            reasons = {item["reason"] for item in data["skipped"] if item["branch"] == "issue-99-foo"}  # type: ignore[index]
+            self.assertEqual(reasons, {"unmerged"})
+
+    def test_non_github_remote_skips_detection_silently(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = RepoFixture.create(root)
+            make_squash_merged_branch(fixture.repo, "issue-99-foo")
+            # Origin already points at the local bare repo (not github.com).
+            bin_dir = install_fake_gh(root, {"issue-99-foo": [{"number": 99}]})
+            env = env_without_real_gh(bin_dir)
+
+            result, data = self.run_script(
+                fixture.repo, "--base", "main", "--no-fetch", env=env,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            self.assertEqual(data["errors"], [])
+            reasons = {item["reason"] for item in data["skipped"] if item["branch"] == "issue-99-foo"}  # type: ignore[index]
+            self.assertEqual(reasons, {"unmerged"})
+
+    def test_gh_failure_recorded_but_does_not_abort(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = self._setup_squash_fixture(root)
+            # Also create a normally-merged branch that should still be deleted.
+            make_merged_branch(fixture.repo, "merged-delete")
+            bin_dir = install_fake_gh(root, fail=True)
+            env = env_without_real_gh(bin_dir)
+
+            result, data = self.run_script(
+                fixture.repo, "--base", "main", "--no-fetch", "--yes", env=env,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            error_reasons = {e["reason"] for e in data["errors"]}  # type: ignore[index]
+            self.assertIn("pr_check_failed", error_reasons)
+            self.assertFalse(branch_exists(fixture.repo, "merged-delete"))
+            self.assertTrue(branch_exists(fixture.repo, "issue-99-foo"))
+
+    def test_reachability_merged_still_uses_safe_delete(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            fixture = RepoFixture.create(root)
+            make_merged_branch(fixture.repo, "true-merged")
+            git(fixture.repo, "remote", "set-url", "origin", "git@github.com:fake/repo.git")
+            bin_dir = install_fake_gh(root, {})  # No PR data; gh would return [] for any branch.
+            env = env_without_real_gh(bin_dir)
+
+            result, data = self.run_script(
+                fixture.repo, "--base", "main", "--no-fetch", env=env,
+            )
+
+            self.assertEqual(result.returncode, 0)
+            planned = [a for a in data["actions"] if a["type"] == "delete_branch" and a["branch"] == "true-merged"]  # type: ignore[index]
+            self.assertEqual(len(planned), 1)
+            self.assertEqual(planned[0]["reason"], "merged_branch")
+            self.assertEqual(planned[0]["command"], ["git", "branch", "-d", "true-merged"])
+            self.assertNotIn("detail", planned[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #47

## Summary

Adds GitHub PR-merged detection to `git-prune-worktrees` so branches merged via squash/rebase (which break `git merge-base --is-ancestor`) are no longer manual cleanup cases.

For each branch that fails the reachability check, the script now queries `gh pr list --state merged --head <branch> --base <base>`. If a merged PR is found, the branch is deleted with `git branch -D` and the action records `reason: merged_branch_via_pr` and `detail: merged via PR #<N>` as audit evidence.

Detection is default-on when `gh` is on PATH and the configured remote points to GitHub; otherwise it silently no-ops. `--no-detect-pr-merged` opts out. Per-branch `gh` failures are recorded as `pr_check_failed` errors but do not abort other cleanup work.

`SKILL.md` "Safety model" is updated to document the relaxed force-delete invariant: `git branch -D` is permitted only for PR-verified branches, and the PR# is the recorded audit trail.

## Validation

```
$ cd skills/git-prune-worktrees/scripts && python3 -m unittest test_git_prune_worktrees -v
test_current_branch_requires_switch_base_or_is_skipped ... ok
test_dry_run_makes_no_cleanup_changes_and_reports_stable_keys ... ok
test_fetch_failure_with_yes_stops_before_cleanup ... ok
test_gh_failure_recorded_but_does_not_abort ... ok
test_gh_missing_silently_falls_back ... ok
test_local_slash_base_branch_is_not_treated_as_remote ... ok
test_no_detect_pr_merged_disables_detection ... ok
test_non_github_remote_skips_detection_silently ... ok
test_pr_merged_branch_force_deleted_with_pr_detail ... ok
test_reachability_merged_still_uses_safe_delete ... ok
test_yes_removes_only_clean_merged_worktrees_and_branches ... ok
----------------------------------------------------------------------
Ran 11 tests in 6.233s
OK
```

5 pre-existing tests pass unchanged; 6 new tests cover detection + force-delete with PR#, `--no-detect-pr-merged` opt-out, `gh` missing → silent fallback, non-GitHub remote → silent skip, gh failure recorded but non-blocking, and reachability-merged branches still using `git branch -d`.

## Test plan

- [x] All existing tests pass unchanged
- [x] New tests cover all six acceptance criteria scenarios
- [x] `--help` output reflects the new `--no-detect-pr-merged` flag
- [x] SKILL.md documents the relaxed force-delete invariant

🤖 Generated with [Claude Code](https://claude.com/claude-code)