### PR TITLE
fix(git-prune-worktrees): detect squash-merged branches with OID-diverged local tips

### DIFF
--- a/skills/git-prune-worktrees/SKILL.md
+++ b/skills/git-prune-worktrees/SKILL.md
@@ -37,8 +37,8 @@ The script is the source of truth for cleanup eligibility. Do not duplicate its 
 
 ## Approval and failure handling
 
-- Dry-run mode uses `git fetch --dry-run --prune`; it should not mutate refs.
-- `--yes` may run `git fetch --prune`, `git worktree remove`, `git switch`, `git merge --ff-only`, `git branch -d`, `git branch -D` (only for PR-verified branches; see Safety model), and `git worktree prune`.
+- Dry-run mode uses `git fetch --dry-run --prune`; it should not mutate refs. However, `git fetch origin <sha>` may be run in both modes to fetch specific PR head commits for ancestry and tree checks; this downloads a loose object only and does not mutate branches.
+- `--yes` may run `git fetch --prune`, `git fetch origin <sha>` (PR head for OID-mismatch checks), `git worktree remove`, `git switch`, `git merge --ff-only`, `git branch -d`, `git branch -D` (only for PR-verified branches; see Safety model), and `git worktree prune`.
 - If network access or `.git` mutation is blocked by the environment, use the environment's normal approval path. Do not bypass Git by deleting files manually.
 - The script must not use `git worktree remove --force`.
 
@@ -47,9 +47,14 @@ The script is the source of truth for cleanup eligibility. Do not duplicate its 
 A branch is considered merged when either condition holds:
 
 1. **Reachability**: the branch tip is reachable from `--base` (true merge or fast-forward). Action uses `git branch -d` and reports `reason: merged_branch`.
-2. **PR-verified**: a merged GitHub PR exists with `head = <branch>` and `base = <base>`, **and** the local branch tip OID equals the PR's recorded `headRefOid` (covers squash and rebase merges). Action uses `git branch -D` and reports `reason: merged_branch_via_pr` with `detail: merged via PR #<N>` recording the evidence.
+2. **PR-verified**: a merged GitHub PR exists with `head = <branch>` and `base = <base>`, and at least one of the following holds:
+   - **(a) exact match**: the local branch tip OID equals the PR's recorded `headRefOid`.
+   - **(b) tree equality**: after fetching the PR head via `git fetch origin <headRefOid>`, the local branch tip and the PR head share the same file-tree OID (`<tip>^{tree} == <pr_head>^{tree}`). Covers cases where commit metadata (timestamp, author) differs but file content is identical — e.g., independent re-creation of the same commit by separate agents.
+   - **(c) ancestry**: after fetching the PR head, the local tip is a strict ancestor (`git merge-base --is-ancestor`). Covers cases where the remote branch was extended beyond the local branch before merging.
 
-`git branch -D` is permitted only for case 2; the recorded PR# is required as the audit trail. The headRefOid match guards against branch-name reuse: if a branch was deleted and recreated (or extended with new local commits) after a PR with the same name was merged, the local tip will not match the merged PR's head and the branch is treated as unmerged. Cherry-picks without an associated merged PR remain manual cleanup cases.
+   If `git fetch origin <headRefOid>` fails (server does not support SHA fetch or network error), the branch is treated as unmerged (safe fallback). Action uses `git branch -D` and reports `reason: merged_branch_via_pr` with `detail: merged via PR #<N>` recording the evidence.
+
+`git branch -D` is permitted only for case 2; the recorded PR# is required as the audit trail. All three sub-checks guard against branch-name reuse: new local commits added after a PR was merged will differ in tree content and will not be ancestors of the old PR's `headRefOid`. Cherry-picks without an associated merged PR remain manual cleanup cases.
 
 PR detection is enabled by default. It is automatically and silently skipped when `gh` is not on PATH or when the selected remote URL does not contain `github.com`. Use `--no-detect-pr-merged` to disable it explicitly. Per-branch `gh` failures are reported as `pr_check_failed` errors but do not abort the run.
 

--- a/skills/git-prune-worktrees/scripts/git_prune_worktrees.py
+++ b/skills/git-prune-worktrees/scripts/git_prune_worktrees.py
@@ -373,18 +373,47 @@ def pr_merged_via_gh(
         items = json.loads(completed.stdout or "[]")
     except json.JSONDecodeError as exc:
         return None, error_record("pr_check_failed", command, str(exc), branch)
-    # Require the local branch tip to match the PR's recorded head SHA. The
-    # --head filter is a name-only match, so without this check a reused branch
-    # name (old PR merged, new local commits added) would falsely verify and
-    # the subsequent `git branch -D` would destroy the new commits.
+    oid_mismatch_candidates: list[tuple[int, str]] = []
     for item in items:
         if not isinstance(item, dict):
             continue
-        if item.get("headRefOid") != branch_oid:
-            continue
+        pr_head_oid = item.get("headRefOid", "")
         number = item.get("number")
-        if isinstance(number, int):
+        if not isinstance(number, int) or not pr_head_oid:
+            continue
+        if pr_head_oid == branch_oid:
+            # Exact match: local tip was the PR head at merge time.
             return number, None
+        oid_mismatch_candidates.append((number, pr_head_oid))
+
+    # OID-mismatch fallback: the remote branch may have diverged from the local
+    # branch (e.g., force-push, rebase, or independent re-creation with the same
+    # content) before merging, causing OID divergence even though all local work
+    # was incorporated. Fetch the PR head then apply two checks:
+    #   1. Tree equality: identical file-tree means identical content regardless
+    #      of commit metadata (timestamp, author). Covers independent re-creation
+    #      and metadata-only rebases.
+    #   2. Ancestry: local tip is a strict ancestor of the PR head, meaning the
+    #      remote branch was extended beyond the local branch before merging.
+    # Either check passing is sufficient evidence of incorporation.
+    # Branch-name reuse is still guarded: new local commits after the PR merged
+    # will differ in tree content and will not be ancestors of the old PR head.
+    for number, pr_head_oid in oid_mismatch_candidates:
+        fetch_result = run_git(["fetch", "origin", pr_head_oid], repo)
+        if fetch_result.returncode != 0:
+            continue  # SHA fetch failed or unsupported; treat as unmerged.
+        local_tree = run_git(["rev-parse", f"{branch_oid}^{{tree}}"], repo)
+        pr_tree = run_git(["rev-parse", f"{pr_head_oid}^{{tree}}"], repo)
+        if (
+            local_tree.returncode == 0
+            and pr_tree.returncode == 0
+            and local_tree.stdout.strip() == pr_tree.stdout.strip()
+        ):
+            return number, None
+        ancestor_result = run_git(["merge-base", "--is-ancestor", branch_oid, pr_head_oid], repo)
+        if ancestor_result.returncode == 0:
+            return number, None
+
     return None, None
 
 


### PR DESCRIPTION
Closes #58

## Summary

- `pr_merged_via_gh` の exact-match が失敗した場合に2段階のフォールバックを追加
- **Tree equality**: `git fetch origin <headRefOid>` 後に `<tip>^{tree} == <pr_head>^{tree}` を比較。コミットメタデータ（タイムスタンプ・author）は異なるがファイル内容が同一のケース（エージェントが並列に同一コミットを生成した場合など）を検出
- **Ancestry**: ローカル tip が PR head の祖先かを `merge-base --is-ancestor` で確認。remote ブランチがローカルより先に進んでからマージされたケースを検出
- SHA fetch 失敗時はフォールバックせず unmerged 扱い（安全側倒し）
- branch-name reuse ガードは維持：新規コミットは tree が変わり祖先関係も崩れるため誤検知しない

## 再現ケース（hermes-engineering）

```
PR #93 headRefOid: 41b294c0  (remote)
local branch tip:  816c4348  (ローカルで独立生成)
tree OID:          c0abe5a4  (両者で完全一致)
→ 修正前: unmerged とスキップ
→ 修正後: merged via PR #93 として削除対象に
```

## Validation

```
python3 skills/git-prune-worktrees/scripts/git_prune_worktrees.py  # dry-run
python3 skills/git-prune-worktrees/scripts/git_prune_worktrees.py --yes
```

hermes-engineering の `issue-92-enable-bwrap-in-devcontainer` ブランチで dry-run を実行し、`merged via PR #93` として検出されることを確認予定。