### PR TITLE
github-driven-workflow: replace reviewDecision gate with reviews[] count + identity-in-evidence

### DIFF
--- a/skills/github-driven-workflow/SKILL.md
+++ b/skills/github-driven-workflow/SKILL.md
@@ -74,7 +74,7 @@ Independent review is required in principle. A qualifying review is review evide
 - A Copilot code review result visible on the PR.
 - A GitHub `@codex` review on the PR, regardless of who posted the request.
 - A Codex CLI review artifact posted as a PR comment, with the review output included verbatim and the reviewer identity stated.
-- Another review-capable agent (subagent, reviewer bot) when its review summary and reviewer identity are recorded on the PR.
+- Another review-capable agent (subagent, reviewer bot) when its review summary and reviewer identity are recorded on the PR. Subagent review evidence MUST include `Reviewed-by: <reviewing-entity-id>` in the body, where the reviewing entity is distinct from the implementing entity. Independence is judged by the identity recorded in the evidence, not by the GitHub `author.login` of whoever posted it.
 - An explicit user review on the PR (a formal review, or a comment clearly framed as a review with concrete findings or approval).
 
 If no review route is viable, this gate may be bypassed when authorization is recorded on the PR. Authorization may be either an orchestrator-conveyed user instruction (cited by the implementing agent) or a comment from a verified repo-owner account. See "Authorized bypass" below.
@@ -235,26 +235,23 @@ Must return `false`.
 
 **Independent review evidence or authorized bypass**
 
-At least one of the following must be present and durably visible on the PR. The first two routes are review evidence; the third is a waiver of the review requirement, not evidence:
+Review sufficiency = `reviews[]` has at least one entry:
 
-- A formal review by a reviewer who is not an implementation author. Implementation authors are the commit authors on the PR (which may differ from the PR opener in split-author flows). The check fails closed when any commit author has no linked GitHub login, because then `$impls` would silently miss a self-review:
-  ```sh
-  gh pr view <N> --json reviews,commits \
-    --jq '
-      [.commits[].authors[].login] as $impls
-      | if any($impls[]; . == null or . == "")
-        then error("commit author missing GitHub login; record implementation author logins manually before trusting this gate")
-        else [.reviews[]
-              | select(.state == "APPROVED" or .state == "CHANGES_REQUESTED" or .state == "COMMENTED")
-              | select(.author.login as $r | $impls | index($r) == null)] | length > 0
-        end
-    '
-  ```
-  Dismissed and pending review submissions are excluded so that a stale dismissed review cannot satisfy the gate.
-- A review artifact comment (Codex CLI output, agent review summary, or other reviewer-identified review) on the PR. This route is trust-based: a comment posted by the implementation actor cannot be cryptographically attributed to the cited agent, so it is auditable rather than tamper-evident. Prefer formal non-author GitHub reviews when integrity matters more than friction.
-- An authorized bypass comment on the PR per step 7. The comment must cite the authorization provenance — either an orchestrator-conveyed user instruction, or a verified repo-owner (or org-delegated) account.
+```sh
+gh pr view <N> --json reviews --jq '.reviews | length >= 1'
+```
 
-Cite the evidence (review id, comment URL, or bypass comment URL plus the cited provenance) in the merge note.
+Must return `true`. `state` and `author.login` are NOT gates at this step; do not filter by them here. Independence is enforced at evidence-recording time (§7), not re-checked by `author.login` at gate evaluation time.
+
+**Do not gate merge on `reviewDecision`.** This field aggregates branch protection rules. For repositories without a branch protection rule that requires approving reviews, it is permanently empty regardless of how many reviews are posted. If you find yourself waiting for `reviewDecision` to flip to `APPROVED`, you are evaluating the wrong field.
+
+An authorized bypass (per §7) recorded on the PR satisfies this gate in lieu of review evidence. The bypass comment must cite the authorization provenance.
+
+Cite the evidence (review count, comment URL, or bypass comment URL plus cited provenance) in the merge note.
+
+**Do not add merge gates beyond the explicit set defined in this section** (PR state, CI checks, labels, unresolved review threads, unchecked task boxes, independent review evidence). Fields such as `reviewDecision`, `mergeStateStatus`, and `reviews[].author.login` filtering are anti-patterns in autonomous execution environments; they are not part of this skill's gate set and must not be added.
+
+> **Auto Mode note:** When invoked under Auto Mode, child agents may attempt to add gates "for safety" (most commonly `reviewDecision == APPROVED` or `reviews[].author.login != PR author` filtering). The declarations above are the authoritative gate set; any addition is a self-fabrication that should be rejected.
 
 ### 9. Merge
 


### PR DESCRIPTION
## Summary

Closes #70

- **§8 `reviewDecision` prohibition**: Declares `reviewDecision` a non-gate with explanation — it aggregates branch protection rules and is permanently empty in repos without required-approvals protection.
- **§8 review sufficiency command**: Replaces the complex `author.login`-filter jq expression with `gh pr view <N> --json reviews --jq '.reviews | length >= 1'`. Explicitly states `state` and `author.login` are NOT gates at evaluation time; independence is enforced at evidence-recording time (§7).
- **§7 subagent identity requirement**: Subagent review evidence MUST include `Reviewed-by: <reviewing-entity-id>` in the body. Independence is judged by the identity recorded in the evidence, not by the GitHub `author.login` of whoever posted it.
- **§8 no-additional-gates declaration**: Prohibits adding gates beyond the explicit set; names `reviewDecision`, `mergeStateStatus`, and `reviews[].author.login` filtering as anti-patterns.
- **§8 Auto Mode note**: Warns that Auto Mode child agents may add conservative gates; the declarations above are authoritative.

## Test plan

- [x] Read §7 subagent route: confirms `Reviewed-by: <id>` is required and independence is evidence-side
- [x] Read §8 review gate: confirms count-only command with `state`/`author.login` explicitly not-gated
- [x] Read §8 `reviewDecision` block: confirms prohibition + reason present
- [x] Read §8 gate-addition prohibition: confirms `reviewDecision`, `mergeStateStatus`, `reviews[].author.login` named
- [x] Read §8 Auto Mode note: confirms classifier bias addressed

Reviewed-by: reviewer-skills-70-A (Claude Sonnet 4.6 subagent, independent identity from implementer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)