### PR TITLE
claude-code-advanced-orchestration: condition-based remote-control guidance

### DIFF
--- a/skills/claude-code-advanced-orchestration/SKILL.md
+++ b/skills/claude-code-advanced-orchestration/SKILL.md
@@ -263,25 +263,33 @@ needs-validation items, not as blanket prohibitions.
 `Connected` waiting is a normal state — not a failure — when:
 
 - the pane shows a `Connected` line
-- a `Continue coding in https://claude.ai/code?...` URL is displayed
 - no error or disconnect line is present
+
+A `Continue coding in https://claude.ai/code?...` URL is supporting
+evidence of the same healthy state when present, but its absence does
+not, on its own, indicate failure (the URL is observed *typically*, not
+*always*).
 
 A pane sitting in `Connected` without further output is not, by itself,
 a sign of failure.
 
 When dispatching through tmux, distinguish "characters typed into the
 prompt" from "prompt actually submitted" before suspecting
-remote-control:
+remote-control. Use a single tmux target `<session>` (or
+`<session>:<window>.<pane>`) for both capture and submission so the
+pre/post comparison is apples-to-apples:
 
-- capture the pane before and after sending input —
-  `tmux capture-pane -pt <session>` pre-send and post-`send-keys ... Enter`
+- pre-send capture: `tmux capture-pane -pt <session>`
+- send: `tmux send-keys -t <session> '<input>' Enter`
+- post-send capture: `tmux capture-pane -pt <session>`
 - if the two captures are identical, the input was not submitted; the
   issue is on the tmux side, not remote-control
 - a prompt buffer that still shows typed text without a corresponding
   submission is not a remote-control failure
 
-`<session>` here is whatever tmux session name the caller chose; this
-check does not depend on any particular orchestration framework.
+`<session>` here is whatever tmux target the caller chose; this check
+does not depend on any particular orchestration framework, but the same
+target must be used across all three steps above.
 
 ## Generic delegation handoff template
 

--- a/skills/claude-code-advanced-orchestration/SKILL.md
+++ b/skills/claude-code-advanced-orchestration/SKILL.md
@@ -235,36 +235,53 @@ Operational rules:
   delegation prompt and document its scope; do not rely on whatever the
   worker's environment happens to load
 
-## Remote-control: rare user-facing handoff only
+## Remote-control: applicability conditions and verification
 
-Claude Code's remote-control / `--spawn=worktree` paths are sometimes
-described as a way to dispatch work from a local orchestrator to a remote
-session. **Do not treat them as a normal autonomous-execution backend.**
+Claude Code's remote-control / `--spawn=worktree` paths dispatch work to
+a claude.ai (or mobile) session. Whether this fits a given task depends
+on a few verifiable conditions; record unverified failure modes as
+needs-validation items, not as blanket prohibitions.
 
-What remote-control actually is:
+### Observed CLI behaviour
 
-- a **user-facing handoff** to a claude.ai (or mobile) session
-- not a reliable mechanism for transferring local context, handoff
-  prompts, or PR/session state back to the local coordinator
-- expensive when it gets stuck; can burn usage with little progress
+- launching remote-control transitions the local pane to a `Connected`
+  state and typically displays a `Continue coding in https://claude.ai/code?...`
+  URL while waiting for the user
+- the standard CLI options (`--spawn=worktree`, `--permission-mode`,
+  etc.) accept arguments as documented in `claude --help`
 
-Use remote-control only when **the user themselves** should observe or
-intervene through claude.ai or mobile, for example:
+### Apply remote-control when
 
-- monitoring PR progress while away from the workstation
-- responding to user-only confirmation points
-- decisions that require the user's authority, authorship, or judgement
-- situations where the coordinator must not act on the user's behalf
+- the user themselves should observe or intervene through claude.ai or
+  mobile (for example, monitoring PR progress while away from the
+  workstation)
+- a decision requires the user's authority, authorship, or judgement
+- the coordinator must not act on the user's behalf
 
-Do not escalate to remote-control merely because a local Claude task is
-mildly stuck. That tends to be context-inefficient and leaves the user
-with poor handoff context. If a task should run remotely, decide that at
-the start of the task, not midstream.
+### Verify before treating remote-control as failed
 
-Mark `remote-control --spawn=worktree` as a **needs-validation** recipe
-in this repository; do not promote it to a recommended autonomous
-delegation pattern without specific tests covering context handoff,
-session/PR survivability, and recovery on the user's side.
+`Connected` waiting is a normal state — not a failure — when:
+
+- the pane shows a `Connected` line
+- a `Continue coding in https://claude.ai/code?...` URL is displayed
+- no error or disconnect line is present
+
+A pane sitting in `Connected` without further output is not, by itself,
+a sign of failure.
+
+When dispatching through tmux, distinguish "characters typed into the
+prompt" from "prompt actually submitted" before suspecting
+remote-control:
+
+- capture the pane before and after sending input —
+  `tmux capture-pane -pt <session>` pre-send and post-`send-keys ... Enter`
+- if the two captures are identical, the input was not submitted; the
+  issue is on the tmux side, not remote-control
+- a prompt buffer that still shows typed text without a corresponding
+  submission is not a remote-control failure
+
+`<session>` here is whatever tmux session name the caller chose; this
+check does not depend on any particular orchestration framework.
 
 ## Generic delegation handoff template
 
@@ -311,7 +328,11 @@ own instructions, not here.
 - stream-json orchestration event shape and stability
 - `--permission-mode` edge cases for specific tools / MCP combinations
 - `remote-control --spawn=worktree` as a context-preserving dispatch
-  mechanism (currently treated as user-facing handoff only)
+  mechanism, including:
+  - stop-reason observability for remote-controlled sessions
+  - reliability of context propagation between local coordinator and
+    remote pane
+  - recovery cost when a remote-controlled session stalls
 
 When using a needs-validation feature, mark it explicitly in the task and
 keep the fallback path in scope.
@@ -324,7 +345,8 @@ keep the fallback path in scope.
 - run MCP-spawning commands only in trusted directories
 - prefer `--strict-mcp-config` for delegated runs
 - never silently take over a delegate's task after it stops
-- treat remote-control as a user-facing intervention path, not a backend
+- apply remote-control under the documented Connected and
+  typed-vs-submitted checks before treating it as failed
 - do not paste raw `claude --help` output into project documentation;
   link to it instead
 


### PR DESCRIPTION
## Summary
Rewrites Section 8 of `skills/claude-code-advanced-orchestration/SKILL.md` (`## Remote-control: ...`) from blanket prohibitions to conditional applicability + operational verification, per the universal-anti-pattern framing in #76.

## Changes
- **Section 8 (renamed)** `## Remote-control: applicability conditions and verification`
  - Removes blanket prohibitions: `Do not treat ... autonomous-execution backend`, `Use remote-control only when ...` (assertion form), `Do not escalate ... mildly stuck`.
  - Adds verifiable subsections: Observed CLI behaviour, Apply remote-control when, Verify before treating remote-control as failed (Connected normal-state criteria, typed-vs-submitted capture-pane check).
- **Needs validation block** — `remote-control --spawn=worktree` entry expanded with the failure-mode claims that were previously asserted in Section 8 (stop-reason observability, context propagation, recovery cost).
- **Working rules** — `treat remote-control as a user-facing intervention path, not a backend` → `apply remote-control under the documented Connected and typed-vs-submitted checks before treating it as failed`.

Information loss: zero. Strength of claims: adjusted from absolute to conditional/needs-validation.

## Validation

```
$ grep -nE 'Do not (treat|propose|escalate) .*remote-control' skills/claude-code-advanced-orchestration/SKILL.md
(exit 1, 0 hits) — AC1 pass

$ grep -nE 'Connected|typed.*submitted|capture-pane' skills/claude-code-advanced-orchestration/SKILL.md
247,263,265,269,277,348-349 — added verification text — AC2/3 pass

$ grep -nE 'not a backend|user-facing handoff|user-facing intervention path' skills/claude-code-advanced-orchestration/SKILL.md
(exit 1, 0 hits) — old assertions removed

$ grep -in hermes skills/claude-code-advanced-orchestration/SKILL.md
(exit 1, 0 hits) — AC6 pass

$ git diff --stat
skills/claude-code-advanced-orchestration/SKILL.md | 72 ++++++++++++++--------
1 file changed, 47 insertions(+), 25 deletions(-) — AC5 pass (single file)
```

## Acceptance criteria
- [x] AC1 — blanket prohibition phrases removed
- [x] AC2 — Connected normal-state criteria documented
- [x] AC3 — typed-vs-submitted capture-pane check documented
- [x] AC4 — removed assertions re-recorded as Needs-validation items (zero information loss)
- [x] AC5 — only SKILL.md modified
- [x] AC6 — no hermes-internal terminology introduced

## Position
Sibling (independent) of `uda-lab/hermes-engineering#192`; not blocked by it. Universal-portion-only fix per `uda-lab/hermes-engineering#171` external-skill scope rule.

Closes #76