### PR TITLE
github-driven-workflow: disambiguate dispatch vs evidence in acquire-review.sh

### DIFF
--- a/skills/github-driven-workflow/SKILL.md
+++ b/skills/github-driven-workflow/SKILL.md
@@ -61,7 +61,9 @@ Run the review acquisition script with `<OWNER>/<REPO> <PR_NUMBER>`:
 
 A project-specific override must accept the same `<OWNER>/<REPO> <PR_NUMBER>` arguments and exit 0 on success. Exit-code matrices may differ between implementations; **callers should treat any nonzero exit as "review not acquired"** and proceed to authorized bypass per below. Implementations are encouraged but not required to use exit 64 for usage error and exit 127 for missing dependencies.
 
-The bundled default tries Copilot → `@codex` mention → Codex CLI artifact in order and prints `route: <name>` on success. Acceptable evidence on the PR:
+The bundled default tries Copilot → `@codex` mention → Codex CLI artifact in order and prints `route: <name> (dispatched)` or `route: <name> (evidence)` on success. The token distinguishes whether evidence is already on the PR: `(dispatched)` means only that an async request was sent (Copilot reviewer assigned, `@codex` mention posted) and the §8 evidence gate is **not** yet satisfied; `(evidence)` means a synchronous artifact comment was posted (e.g. Codex CLI) and the §8 gate can match it directly. **Callers must not equate `route: <name>` alone with merge-readiness — only the §8 gate determines that.** For dispatched routes, wait briefly and re-check §8; if evidence does not accrue within a reasonable wait, switch routes or proceed to authorized bypass per below.
+
+Acceptable evidence on the PR:
 
 - A formal GitHub PR review (approved, changes requested, or commented) by a non-author human.
 - A Copilot code review result.

--- a/skills/github-driven-workflow/acquire-review.sh
+++ b/skills/github-driven-workflow/acquire-review.sh
@@ -3,15 +3,21 @@
 # Tries Copilot review → @codex mention → Codex CLI artifact in order.
 # Override by setting REVIEW_ACQUIRE_SCRIPT to a project-specific implementation.
 #
-# Semantics: exit 0 means the review request was *dispatched* (reviewer
-# assigned, mention posted, or artifact comment posted), not that
-# qualifying review evidence is already on the PR. Async routes
-# (Copilot, @codex) require waiting; whether evidence has accrued is
-# decided by the §8 merge gate (`reviews[] | length >= 1`), not here.
+# Semantics: exit 0 means a route succeeded, but the printed token
+# distinguishes whether evidence is already on the PR.
+#   - "route: <name> (dispatched)" — async request sent (reviewer
+#     assigned or @codex mention posted). No evidence yet on the PR;
+#     the §8 merge gate will not pass on this alone. Caller must wait
+#     and re-check, switch routes, or record an authorized bypass.
+#   - "route: <name> (evidence)" — synchronous artifact comment was
+#     posted on the PR (e.g. Codex CLI). Evidence is durably present
+#     and the §8 merge gate can match it directly.
+# Whether evidence has accrued for dispatched routes is decided by
+# the §8 merge gate, not here.
 #
 # Usage: acquire-review.sh <OWNER>/<REPO> <PR_NUMBER>
 # Exit codes:
-#   0   one route was dispatched (printed: "route: <name>")
+#   0   one route succeeded (printed: "route: <name> (dispatched|evidence)")
 #   1   all routes failed; record an authorized bypass per SKILL.md §7
 #   64  usage error
 #   127 precondition error (e.g. `gh` CLI missing)
@@ -60,15 +66,15 @@ route_codex_cli() {
 }
 
 if route_copilot >/dev/null 2>&1; then
-  echo "route: copilot"
+  echo "route: copilot (dispatched)"
   exit 0
 fi
 if route_codex_mention >/dev/null 2>&1; then
-  echo "route: codex_mention"
+  echo "route: codex_mention (dispatched)"
   exit 0
 fi
 if route_codex_cli; then
-  echo "route: codex_cli"
+  echo "route: codex_cli (evidence)"
   exit 0
 fi
 

--- a/skills/github-driven-workflow/test_acquire_review.sh
+++ b/skills/github-driven-workflow/test_acquire_review.sh
@@ -101,12 +101,12 @@ check '[[ "$rc" == "127" ]]' "gh missing ⇒ exit 127"
 # --- copilot route succeeds ---
 write_fake_gh 0 0; remove_codex
 out="$(run_acquire owner/repo 1)"
-check '[[ "$out" == *"route: copilot"* ]]' "copilot success ⇒ route: copilot"
+check '[[ "$out" == *"route: copilot (dispatched)"* ]]' "copilot success ⇒ route: copilot (dispatched)"
 
 # --- copilot fails, codex_mention succeeds ---
 write_fake_gh 1 0; remove_codex
 out="$(run_acquire owner/repo 1)"
-check '[[ "$out" == *"route: codex_mention"* ]]' "copilot 422 ⇒ codex_mention"
+check '[[ "$out" == *"route: codex_mention (dispatched)"* ]]' "copilot 422 ⇒ codex_mention (dispatched)"
 
 # --- both gh routes fail, no codex CLI ⇒ exit 1 ---
 write_fake_gh 1 1; remove_codex
@@ -124,7 +124,7 @@ echo "Codex CLI review artifact"
 EOF
 chmod +x "${BIN}/codex"
 out="$(run_acquire owner/repo 1)"
-check '[[ "$out" == *"route: codex_cli"* ]]' "codex CLI fallback ⇒ route: codex_cli"
+check '[[ "$out" == *"route: codex_cli (evidence)"* ]]' "codex CLI fallback ⇒ route: codex_cli (evidence)"
 check 'grep -q "argv:.*pr comment.*--body-file" "${GH_LOG}"' "codex CLI fallback ⇒ gh pr comment invoked with --body-file"
 check 'grep -q "## Codex CLI review" "${GH_LOG}"' "codex CLI body has 'Codex CLI review' header"
 check 'grep -q "Reviewed-by: codex-cli" "${GH_LOG}"' "codex CLI body has 'Reviewed-by: codex-cli' line"


### PR DESCRIPTION
## Summary

Closes #79.

`acquire-review.sh` previously printed `route: <name>` on any successful route — whether the route had actually placed evidence on the PR (Codex CLI artifact) or only dispatched an async request (Copilot reviewer assignment, `@codex` mention). Caller agents could not tell the difference and would narrate "review acquired" while silently waiting on routes that would never deliver.

This PR adopts options **A + C** from the issue's proposed direction:

- **Script (option A)** — success line now carries a single disambiguating token:
  - `route: copilot (dispatched)` — async, no evidence on PR yet.
  - `route: codex_mention (dispatched)` — async, no evidence on PR yet.
  - `route: codex_cli (evidence)` — synchronous artifact comment posted; §8 gate can match it directly.
- **§7 (option C)** — adds an explicit paragraph: dispatched ≠ merge-ready; the §8 gate is the sole arbiter of merge-readiness; for dispatched routes, wait briefly, switch routes, or record an authorized bypass.

Options **B (per-route deliverability pre-checks)** and **D (in-script polling)** are intentionally deferred. Now that PR #84 (closes #81) expands the §8 gate to accept comment-based evidence (`Reviewed-by:` artifacts, owner comment-as-review, authorized bypass), the practical "Copilot dispatched but never reviewed" failure has two cleaner remediations — switching routes or recording a bypass — both of which §7 now directs callers to. B/D add friction without changing the outcome and can be revisited if a real silent-no-op recurs.

## Validation

- `bash skills/github-driven-workflow/test_acquire_review.sh` → 10 passed, 0 failed (existing five smoke tests cover the new output format; assertions updated).

## Notes for reviewers

- No exit-code changes — `0` still means "a route succeeded." The new information lives in the printed token.
- Header comment in the script updated to spell out the dispatched/evidence distinction.
- §7 wording aligns with the three-clause §8 vocabulary established by PR #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)