### PR TITLE
github-project-board-maintenance: rate-limit-aware Projects v2 board maintenance skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Each skill must live at `skills/<skill-name>/SKILL.md`.
 ### Delivery workflow
 
 - `github-driven-workflow`: enforce issue-first, PR-gated delivery with no direct main pushes, independent review requirement, and deterministic merge gates
+- `github-project-board-maintenance`: rate-limit-aware GitHub Projects v2 board maintenance — REST-first candidate discovery, single GraphQL snapshot, mechanical status-update planning, and guarded apply
 
 ### Randomness
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -33,3 +33,4 @@ Current skills:
 - shell-script-engineering
 - claude-code-advanced-orchestration
 - textlint-cli
+- github-project-board-maintenance

--- a/skills/github-project-board-maintenance/SKILL.md
+++ b/skills/github-project-board-maintenance/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: github-project-board-maintenance
+description: Rate-limit-aware GitHub Projects v2 board maintenance — REST-first candidate discovery, single GraphQL snapshot, mechanical status-update planning, guarded apply. Use whenever a request asks to organise a Project board for issues/PRs updated within the last N hours.
+---
+
+# github-project-board-maintenance
+
+Use this skill when the user asks to organise a GitHub Projects v2 board for
+issues or PRs updated within a recent time window. The bundled script is the
+operational source of truth. Do **not** start with ad hoc `gh project
+item-list` — large item-list calls can consume a substantial part of the
+hourly GraphQL budget.
+
+## Core invocation
+
+```sh
+python3 scripts/project_board_maintenance.py \
+  --repo OWNER/REPO \
+  --since-hours 24 \
+  --project-owner OWNER_OR_ORG \
+  --project-number PROJECT_NUMBER \
+  --status-field "Status" \
+  --status-map status-map.json \
+  --dry-run
+```
+
+Default mode is `--dry-run` (read-only planning) when neither `--dry-run` nor
+`--apply` is given. The script always emits a single JSON object on stdout;
+diagnostics go to stderr.
+
+`--dry-run` is **read-only planning, not cost-free**: it still calls
+`gh api rate_limit`, REST list endpoints, and one paginated GraphQL Project
+snapshot. It performs no mutations.
+
+## Status policy file
+
+A name-based JSON map. The script resolves names against the snapshot's
+field schema and never guesses transitions.
+
+```json
+{
+  "closed_issue": "Done",
+  "merged_pr": "Done",
+  "open_issue": null,
+  "open_pr": null,
+  "draft_pr": null
+}
+```
+
+- string value: propose updating to that status option (by **name**).
+- `null`: inspect but do not propose a change.
+- missing key in dry-run: treated as `null` (skipped with `no_status_policy`).
+- missing key under `--apply`: the run halts with `status_map_invalid`.
+
+## What the script does
+
+1. **Preconditions** — `gh auth status` precheck. Failure produces
+   `errors: [{reason: "gh_not_authenticated"}]` and exits without further calls.
+2. **Rate-limit preflight** — `gh api rate_limit`, recorded as
+   `rate_limit_before`. If `graphql.remaining < 1000` (configurable via
+   `--graphql-threshold`) and `--allow-low-graphql-budget` is not set, the
+   GraphQL snapshot is skipped and all candidates are reported as
+   `low_graphql_budget`.
+3. **REST candidate discovery** — paginates `/repos/.../issues` (filtering out
+   PR rows) and `/repos/.../pulls`, sorted by `updated` descending, stopping
+   when the page's oldest item is older than the cutoff. Dedupes by
+   `(type, number)`.
+4. **Single GraphQL snapshot** — when `--project-owner` and `--project-number`
+   are supplied, the script issues one paginated `gh api graphql` query that
+   returns: project ID, the configured single-select status field's ID and
+   option list, and all Project items with their current status option.
+   Repeated full-board scans are forbidden.
+5. **Mechanical plan** — matches candidates to Project items by
+   `(type, number)` against the target repo, classifies each candidate
+   (`closed_issue`, `merged_pr`, `open_issue`, `open_pr`, `draft_pr`),
+   resolves status-map names to option IDs locally, and emits
+   `proposed_updates` only where current and target option IDs differ.
+6. **Guarded apply** — `--apply` requires every required status-map key to be
+   present and resolve to an option ID; otherwise the run halts. Mutations
+   use the `updateProjectV2ItemFieldValue` GraphQL mutation. `rate_limit_after`
+   is re-read after mutation.
+
+## Output schema
+
+```json
+{
+  "summary":          { "mode": "dry-run", "candidates": N, ... },
+  "rate_limit_before": { "core": {...}, "graphql": {...} },
+  "rate_limit_after":  { "core": {...}, "graphql": {...} },
+  "candidates":       [ { "type", "number", "title", "state", "draft", "merged", "merged_at", "updated_at", "html_url" } ],
+  "matched_items":    [ { "type", "number", "item_id", "current_status_option_id", "current_status_option_name" } ],
+  "proposed_updates": [ { "type", "number", "item_id", "from_option_id", "from_option_name", "to_option_id", "to_option_name", "policy_key" } ],
+  "skipped":          [ { "type", "number", "reason", "detail?" } ],
+  "errors":           [ { "reason", "detail?" } ]
+}
+```
+
+`applied_updates` is added under `--apply`.
+
+### Skip reasons
+
+- `not_on_project`
+- `ambiguous_project_item_match`
+- `no_status_policy`
+- `already_correct`
+- `low_graphql_budget`
+- `project_arguments_missing`
+
+### Error reasons
+
+- `gh_not_authenticated`
+- `unknown_status_option`
+- `gh_command_failed`
+- `status_map_invalid`
+- `bad_repo`
+
+## Agent invocation contract
+
+The script is the safe workbench. Treat its JSON as the source of truth for
+the candidate set, mechanically justified updates, skipped reasons, and
+errors.
+
+The agent must **not**:
+
+- mutate Project items when the script reports `low_graphql_budget`,
+  `ambiguous_project_item_match`, missing status policy, missing Project
+  metadata, or `unknown_status_option`;
+- broaden into repeated full-board scans to compensate for uncertain matching;
+- guess status transitions not encoded in the explicit policy file;
+- start a board-maintenance request with `gh project item-list`.
+
+The agent **does** retain semantic judgement: reading issue/PR bodies,
+comments, linked PRs, dependency state, blocked/priority/milestone judgement,
+and any repo-specific workflow conventions not encoded in the policy file.
+For items the script skips and the user asks about, read the issue/PR
+directly and explain the situation rather than guessing.
+
+## When to re-invoke
+
+The script is idempotent within a single run. Re-run only when:
+
+- the input changed (different `--repo`, `--since-hours`, `--status-map`,
+  Project arguments, or threshold), or
+- a previous `--dry-run` plan has been approved and you are switching to
+  `--apply`, or
+- the previous run reported `low_graphql_budget` and the budget has since
+  recovered.
+
+Do not loop the script hoping for a different classification.

--- a/skills/github-project-board-maintenance/scripts/project_board_maintenance.py
+++ b/skills/github-project-board-maintenance/scripts/project_board_maintenance.py
@@ -236,14 +236,15 @@ def load_status_map(path: str) -> tuple[bool, dict, str]:
 
 def match_items(snapshot: dict, repo: str) -> dict[tuple[str, int], dict]:
     """Build (type, number) -> snapshot item index for the target repo."""
+    repo_lc = repo.lower()
     out: dict[tuple[str, int], dict] = {}
     for node in snapshot["items"]:
         content = node.get("content") or {}
         typename = content.get("__typename")
         if typename not in ("Issue", "PullRequest"):
             continue
-        repo_name = (content.get("repository") or {}).get("nameWithOwner")
-        if repo_name != repo:
+        repo_name = (content.get("repository") or {}).get("nameWithOwner") or ""
+        if repo_name.lower() != repo_lc:
             continue
         kind = "issue" if typename == "Issue" else "pr"
         num = content.get("number")

--- a/skills/github-project-board-maintenance/scripts/project_board_maintenance.py
+++ b/skills/github-project-board-maintenance/scripts/project_board_maintenance.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+"""Rate-limit-aware GitHub Projects v2 board maintenance helper.
+
+Default mode is dry-run (read-only planning). Mutation requires --apply.
+Stdout: single JSON object. Stderr: diagnostics.
+
+dry-run is read-only **planning**, not no-cost: it still calls
+gh api rate_limit, REST list endpoints, and at most one paginated
+GraphQL Project snapshot. It performs no mutations.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+GRAPHQL_THRESHOLD_DEFAULT = 1000
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def run_gh(args: list[str]) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def gh_auth_ok() -> bool:
+    rc, _, _ = run_gh(["auth", "status"])
+    return rc == 0
+
+
+def gh_api_json(args: list[str]) -> tuple[bool, Any, str]:
+    rc, out, err = run_gh(["api", *args])
+    if rc != 0:
+        return False, None, (err.strip() or out.strip())[:500]
+    try:
+        return True, json.loads(out), ""
+    except json.JSONDecodeError as e:
+        return False, None, f"json_decode: {e}"
+
+
+def get_rate_limit() -> tuple[bool, dict, str]:
+    ok, data, err = gh_api_json(["rate_limit"])
+    if not ok:
+        return False, {}, err
+    return True, data.get("resources", {}), ""
+
+
+def parse_iso(ts: str) -> datetime:
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    return datetime.fromisoformat(ts)
+
+
+def fetch_recent(repo: str, since: datetime, kind: str) -> tuple[list[dict], list[dict]]:
+    """Fetch recent issues (kind='issue') or PRs (kind='pr') via REST, paginated to cutoff."""
+    endpoint = "/issues" if kind == "issue" else "/pulls"
+    records: list[dict] = []
+    errors: list[dict] = []
+    page = 1
+    while True:
+        path = (
+            f"/repos/{repo}{endpoint}"
+            f"?state=all&per_page=100&sort=updated&direction=desc&page={page}"
+        )
+        ok, data, err = gh_api_json([path])
+        if not ok:
+            errors.append(
+                {"reason": "gh_command_failed", "detail": f"GET {path}: {err}"}
+            )
+            break
+        if not isinstance(data, list) or not data:
+            break
+        oldest = None
+        for item in data:
+            updated = parse_iso(item["updated_at"])
+            oldest = updated
+            if updated < since:
+                continue
+            if kind == "issue":
+                if item.get("pull_request"):
+                    continue
+                records.append(
+                    {
+                        "type": "issue",
+                        "number": item["number"],
+                        "title": item.get("title", ""),
+                        "state": item.get("state", ""),
+                        "draft": False,
+                        "merged": False,
+                        "merged_at": None,
+                        "updated_at": item["updated_at"],
+                        "html_url": item.get("html_url", ""),
+                    }
+                )
+            else:
+                records.append(
+                    {
+                        "type": "pr",
+                        "number": item["number"],
+                        "title": item.get("title", ""),
+                        "state": item.get("state", ""),
+                        "draft": bool(item.get("draft", False)),
+                        "merged": bool(item.get("merged_at")),
+                        "merged_at": item.get("merged_at"),
+                        "updated_at": item["updated_at"],
+                        "html_url": item.get("html_url", ""),
+                    }
+                )
+        if oldest is None or oldest < since:
+            break
+        page += 1
+    return records, errors
+
+
+PROJECT_QUERY = """
+query($owner: String!, $number: Int!, $statusField: String!, $cursor: String) {
+  organization(login: $owner) {
+    projectV2(number: $number) { ...projFields }
+  }
+  user(login: $owner) {
+    projectV2(number: $number) { ...projFields }
+  }
+}
+fragment projFields on ProjectV2 {
+  id
+  title
+  field(name: $statusField) {
+    __typename
+    ... on ProjectV2SingleSelectField {
+      id
+      name
+      options { id name }
+    }
+  }
+  items(first: 100, after: $cursor) {
+    nodes {
+      id
+      content {
+        __typename
+        ... on Issue { number repository { nameWithOwner } }
+        ... on PullRequest { number repository { nameWithOwner } }
+      }
+      fieldValueByName(name: $statusField) {
+        __typename
+        ... on ProjectV2ItemFieldSingleSelectValue { optionId name }
+      }
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+"""
+
+
+def fetch_project_snapshot(
+    owner: str, number: int, status_field: str
+) -> tuple[bool, dict, str]:
+    """Single paginated GraphQL snapshot of the Project."""
+    cursor: str | None = None
+    project_id: str | None = None
+    field_id: str | None = None
+    field_options: list[dict] = []
+    items: list[dict] = []
+    while True:
+        args = [
+            "graphql",
+            "-f", f"query={PROJECT_QUERY}",
+            "-F", f"owner={owner}",
+            "-F", f"number={number}",
+            "-f", f"statusField={status_field}",
+        ]
+        if cursor is not None:
+            args += ["-f", f"cursor={cursor}"]
+        ok, data, err = gh_api_json(args)
+        if not ok:
+            return False, {}, err
+        if isinstance(data, dict) and data.get("errors"):
+            return False, {}, json.dumps(data["errors"])[:500]
+        d = data.get("data", {}) if isinstance(data, dict) else {}
+        proj = (
+            (d.get("organization") or {}).get("projectV2")
+            or (d.get("user") or {}).get("projectV2")
+        )
+        if not proj:
+            return False, {}, f"project not found: {owner} #{number}"
+        if project_id is None:
+            project_id = proj["id"]
+            field = proj.get("field") or {}
+            if field.get("__typename") == "ProjectV2SingleSelectField":
+                field_id = field.get("id")
+                field_options = field.get("options") or []
+        for node in proj["items"]["nodes"]:
+            items.append(node)
+        page = proj["items"]["pageInfo"]
+        if not page["hasNextPage"]:
+            break
+        cursor = page["endCursor"]
+    return True, {
+        "project_id": project_id,
+        "field_id": field_id,
+        "field_options": field_options,
+        "items": items,
+    }, ""
+
+
+def classify_candidate(c: dict) -> str:
+    if c["type"] == "issue":
+        return "closed_issue" if c["state"] == "closed" else "open_issue"
+    if c.get("merged"):
+        return "merged_pr"
+    if c.get("draft"):
+        return "draft_pr"
+    return "open_pr"
+
+
+def load_status_map(path: str) -> tuple[bool, dict, str]:
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        return False, {}, f"status_map_invalid: {e}"
+    if not isinstance(data, dict):
+        return False, {}, "status_map_invalid: top-level must be an object"
+    return True, data, ""
+
+
+def match_items(snapshot: dict, repo: str) -> dict[tuple[str, int], dict]:
+    """Build (type, number) -> snapshot item index for the target repo."""
+    out: dict[tuple[str, int], dict] = {}
+    for node in snapshot["items"]:
+        content = node.get("content") or {}
+        typename = content.get("__typename")
+        if typename not in ("Issue", "PullRequest"):
+            continue
+        repo_name = (content.get("repository") or {}).get("nameWithOwner")
+        if repo_name != repo:
+            continue
+        kind = "issue" if typename == "Issue" else "pr"
+        num = content.get("number")
+        if num is None:
+            continue
+        key = (kind, int(num))
+        if key in out:
+            out[key] = {"_ambiguous": True}
+        else:
+            out[key] = node
+    return out
+
+
+APPLY_MUTATION = """
+mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $project
+    itemId: $item
+    fieldId: $field
+    value: { singleSelectOptionId: $option }
+  }) {
+    projectV2Item { id }
+  }
+}
+"""
+
+
+def apply_update(project_id: str, item_id: str, field_id: str, option_id: str) -> tuple[bool, str]:
+    args = [
+        "graphql",
+        "-f", f"query={APPLY_MUTATION}",
+        "-f", f"project={project_id}",
+        "-f", f"item={item_id}",
+        "-f", f"field={field_id}",
+        "-f", f"option={option_id}",
+    ]
+    ok, data, err = gh_api_json(args)
+    if not ok:
+        return False, err
+    if isinstance(data, dict) and data.get("errors"):
+        return False, json.dumps(data["errors"])[:500]
+    return True, ""
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--repo", required=True, help="OWNER/REPO")
+    p.add_argument("--since-hours", type=float, required=True)
+    p.add_argument("--project-owner", help="user or org login that owns the Project")
+    p.add_argument("--project-number", type=int)
+    p.add_argument("--status-field", default="Status")
+    p.add_argument("--status-map")
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", default=False)
+    mode.add_argument("--apply", action="store_true", default=False)
+    p.add_argument("--allow-low-graphql-budget", action="store_true", default=False)
+    p.add_argument(
+        "--graphql-threshold",
+        type=int,
+        default=GRAPHQL_THRESHOLD_DEFAULT,
+        help=f"GraphQL remaining-budget stop threshold (default {GRAPHQL_THRESHOLD_DEFAULT})",
+    )
+    args = p.parse_args()
+
+    apply_mode = bool(args.apply)
+    mode_label = "apply" if apply_mode else "dry-run"
+
+    out: dict[str, Any] = {
+        "summary": {"mode": mode_label},
+        "rate_limit_before": {},
+        "rate_limit_after": {},
+        "candidates": [],
+        "matched_items": [],
+        "proposed_updates": [],
+        "skipped": [],
+        "errors": [],
+    }
+    if apply_mode:
+        out["applied_updates"] = []
+
+    if not re.match(r"^[^/]+/[^/]+$", args.repo):
+        out["errors"].append({"reason": "bad_repo", "detail": "expected OWNER/REPO"})
+        print(json.dumps(out, indent=2))
+        return 2
+
+    if apply_mode and not (args.project_owner and args.project_number):
+        out["errors"].append(
+            {
+                "reason": "project_arguments_missing",
+                "detail": "--apply requires --project-owner and --project-number",
+            }
+        )
+        print(json.dumps(out, indent=2))
+        return 2
+
+    if apply_mode and not args.status_map:
+        out["errors"].append(
+            {"reason": "status_map_invalid", "detail": "--apply requires --status-map"}
+        )
+        print(json.dumps(out, indent=2))
+        return 2
+
+    if not gh_auth_ok():
+        out["errors"].append({"reason": "gh_not_authenticated"})
+        print(json.dumps(out, indent=2))
+        return 2
+
+    ok, rl_before, err = get_rate_limit()
+    out["rate_limit_before"] = rl_before
+    if not ok:
+        out["errors"].append({"reason": "gh_command_failed", "detail": err})
+        print(json.dumps(out, indent=2))
+        return 2
+
+    graphql_remaining = (rl_before.get("graphql") or {}).get("remaining", 0)
+    low_budget = graphql_remaining < args.graphql_threshold
+
+    since = datetime.now(timezone.utc) - timedelta(hours=args.since_hours)
+
+    issues, ie = fetch_recent(args.repo, since, "issue")
+    prs, pe = fetch_recent(args.repo, since, "pr")
+    out["errors"].extend(ie)
+    out["errors"].extend(pe)
+
+    seen: set[tuple[str, int]] = set()
+    candidates: list[dict] = []
+    for rec in issues + prs:
+        key = (rec["type"], rec["number"])
+        if key in seen:
+            continue
+        seen.add(key)
+        candidates.append(rec)
+    out["candidates"] = candidates
+
+    project_args_supplied = bool(args.project_owner and args.project_number)
+
+    if not project_args_supplied:
+        for c in candidates:
+            out["skipped"].append(
+                {
+                    "type": c["type"],
+                    "number": c["number"],
+                    "reason": "project_arguments_missing",
+                }
+            )
+        out["summary"].update(_summary(out))
+        print(json.dumps(out, indent=2))
+        return 0 if not apply_mode else 2
+
+    if low_budget and not args.allow_low_graphql_budget:
+        for c in candidates:
+            out["skipped"].append(
+                {
+                    "type": c["type"],
+                    "number": c["number"],
+                    "reason": "low_graphql_budget",
+                    "detail": (
+                        f"graphql.remaining={graphql_remaining} "
+                        f"< threshold={args.graphql_threshold}"
+                    ),
+                }
+            )
+        out["rate_limit_after"] = rl_before
+        out["summary"].update(_summary(out))
+        print(json.dumps(out, indent=2))
+        return 0 if not apply_mode else 2
+
+    status_map: dict = {}
+    if args.status_map:
+        ok, status_map, err = load_status_map(args.status_map)
+        if not ok:
+            out["errors"].append({"reason": "status_map_invalid", "detail": err})
+            if apply_mode:
+                print(json.dumps(out, indent=2))
+                return 2
+
+    if apply_mode:
+        required_keys = {"closed_issue", "merged_pr", "open_issue", "open_pr", "draft_pr"}
+        missing = sorted(required_keys - set(status_map.keys()))
+        if missing or not args.status_map:
+            out["errors"].append(
+                {"reason": "status_map_invalid", "detail": f"missing keys: {missing or '<no file>'} (required in --apply)"}
+            )
+            print(json.dumps(out, indent=2))
+            return 2
+
+    ok, snapshot, err = fetch_project_snapshot(
+        args.project_owner, int(args.project_number), args.status_field
+    )
+    ok2, rl_after, _ = get_rate_limit()
+    out["rate_limit_after"] = rl_after if ok2 else {}
+    if not ok:
+        out["errors"].append({"reason": "gh_command_failed", "detail": err})
+        out["summary"].update(_summary(out))
+        print(json.dumps(out, indent=2))
+        return 2
+
+    if not snapshot.get("field_id"):
+        out["errors"].append(
+            {
+                "reason": "unknown_status_option",
+                "detail": (
+                    f"status field {args.status_field!r} is not a single-select field "
+                    "or was not found"
+                ),
+            }
+        )
+        out["summary"].update(_summary(out))
+        print(json.dumps(out, indent=2))
+        return 2
+
+    name_to_option_id: dict[str, str] = {
+        opt["name"]: opt["id"] for opt in snapshot["field_options"]
+    }
+    desired_option_id: dict[str, str | None] = {}
+    for key, name in status_map.items():
+        if name is None:
+            desired_option_id[key] = None
+            continue
+        if name not in name_to_option_id:
+            out["errors"].append(
+                {
+                    "reason": "unknown_status_option",
+                    "detail": f"{key}={name!r} not in field options",
+                }
+            )
+            desired_option_id[key] = None
+        else:
+            desired_option_id[key] = name_to_option_id[name]
+
+    if apply_mode and any(
+        v is None and status_map.get(k) is not None for k, v in desired_option_id.items()
+    ):
+        print(json.dumps(out, indent=2))
+        return 2
+
+    item_index = match_items(snapshot, args.repo)
+
+    for c in candidates:
+        key = (c["type"], c["number"])
+        if key not in item_index:
+            out["skipped"].append({"type": c["type"], "number": c["number"], "reason": "not_on_project"})
+            continue
+        node = item_index[key]
+        if node.get("_ambiguous"):
+            out["skipped"].append(
+                {"type": c["type"], "number": c["number"], "reason": "ambiguous_project_item_match"}
+            )
+            continue
+        current = node.get("fieldValueByName") or {}
+        current_option_id = current.get("optionId")
+        current_option_name = current.get("name")
+        out["matched_items"].append(
+            {
+                "type": c["type"],
+                "number": c["number"],
+                "item_id": node["id"],
+                "current_status_option_id": current_option_id,
+                "current_status_option_name": current_option_name,
+            }
+        )
+        policy_key = classify_candidate(c)
+        if policy_key not in status_map:
+            out["skipped"].append(
+                {"type": c["type"], "number": c["number"], "reason": "no_status_policy", "detail": policy_key}
+            )
+            continue
+        target_name = status_map[policy_key]
+        if target_name is None:
+            out["skipped"].append(
+                {"type": c["type"], "number": c["number"], "reason": "no_status_policy", "detail": f"{policy_key}=null"}
+            )
+            continue
+        target_option_id = desired_option_id.get(policy_key)
+        if target_option_id is None:
+            continue
+        if current_option_id == target_option_id:
+            out["skipped"].append(
+                {"type": c["type"], "number": c["number"], "reason": "already_correct", "detail": target_name}
+            )
+            continue
+        out["proposed_updates"].append(
+            {
+                "type": c["type"],
+                "number": c["number"],
+                "item_id": node["id"],
+                "from_option_id": current_option_id,
+                "from_option_name": current_option_name,
+                "to_option_id": target_option_id,
+                "to_option_name": target_name,
+                "policy_key": policy_key,
+            }
+        )
+
+    if apply_mode:
+        for upd in out["proposed_updates"]:
+            ok, err = apply_update(
+                snapshot["project_id"], upd["item_id"], snapshot["field_id"], upd["to_option_id"]
+            )
+            if ok:
+                out["applied_updates"].append(
+                    {"type": upd["type"], "number": upd["number"], "item_id": upd["item_id"], "to_option_id": upd["to_option_id"]}
+                )
+            else:
+                out["errors"].append(
+                    {"reason": "gh_command_failed", "detail": f"apply {upd['number']}: {err}"}
+                )
+        ok2, rl_after, _ = get_rate_limit()
+        out["rate_limit_after"] = rl_after if ok2 else out["rate_limit_after"]
+
+    out["summary"].update(_summary(out))
+    print(json.dumps(out, indent=2))
+    return 0 if not out["errors"] else 1
+
+
+def _summary(out: dict) -> dict:
+    s = {
+        "candidates": len(out["candidates"]),
+        "matched": len(out["matched_items"]),
+        "proposed": len(out["proposed_updates"]),
+        "skipped": len(out["skipped"]),
+        "errors": len(out["errors"]),
+    }
+    if "applied_updates" in out:
+        s["applied"] = len(out["applied_updates"])
+    return s
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #89.

## Summary

Adds a compact skill plus bundled Python helper that prevents the known GraphQL rate-limit failure mode for "issues/PRs updated within N hours" board-maintenance requests.

- `skills/github-project-board-maintenance/SKILL.md` — agent invocation contract, output schema, skip/error vocabulary.
- `skills/github-project-board-maintenance/scripts/project_board_maintenance.py` — Python stdlib + `gh` subprocess. Default mode `--dry-run` (read-only planning). Mutation requires `--apply` plus a complete name-based `--status-map`; mutations use `updateProjectV2ItemFieldValue`.
- `skills/README.md`, `README.md` — list the new skill.

Design points (per revised issue #89):

- REST-first candidate discovery; `/issues` filtered to drop PR rows; paginate to time cutoff; dedupe by `(type, number)`.
- One paginated GraphQL snapshot returns project ID, status field schema (option ID + name), and items. Repeated full-board scans are forbidden.
- Status-map values are option **names**; resolved locally against the snapshot's option list. Unknown names yield `errors[]` with `unknown_status_option`.
- Default GraphQL stop threshold is `graphql.remaining < 1000`, override via `--allow-low-graphql-budget`; threshold tunable via `--graphql-threshold`.
- `--apply` fail-closed: requires project args, requires `--status-map`, requires every required key (`closed_issue`, `merged_pr`, `open_issue`, `open_pr`, `draft_pr`), requires every name to resolve; otherwise halts before mutation.

## Validation

Local smoke tests, all on the issue's branch:

```
$ python3 -m py_compile scripts/project_board_maintenance.py
compile OK

$ scripts/project_board_maintenance.py --repo t-uda/skills --since-hours 168 --dry-run
mode: dry-run, candidates: 30, skipped: 30 (project_arguments_missing), errors: 0
graphql_remaining_before: 4972

$ scripts/project_board_maintenance.py --repo bad --since-hours 1
errors: [{'reason': 'bad_repo', ...}]

$ scripts/project_board_maintenance.py --repo t-uda/skills --since-hours 1 --apply
errors: [{'reason': 'project_arguments_missing', 'detail': '--apply requires --project-owner and --project-number'}]

$ scripts/project_board_maintenance.py ... --apply --project-owner foo --project-number 1
errors: [{'reason': 'status_map_invalid', 'detail': '--apply requires --status-map'}]

$ scripts/project_board_maintenance.py ... --apply --status-map /tmp/sm-partial.json
errors: [{'reason': 'status_map_invalid', 'detail': "missing keys: ['draft_pr', 'merged_pr', 'open_issue', 'open_pr'] (required in --apply)"}]

$ scripts/project_board_maintenance.py ... --apply --status-map /tmp/sm-bad.json   # malformed JSON
errors: [{'reason': 'status_map_invalid', 'detail': '...Expecting value...'}]
```

End-to-end mutation paths were not exercised because the test environment has no Project to mutate; the apply guard suite above is the closest deterministic verification without one.

## Test plan

- [x] Script syntax-clean (`py_compile`).
- [x] `--help` lists all flags.
- [x] REST candidate discovery returns recent issues + PRs and dedupes.
- [x] No project args ⇒ all candidates skipped with `project_arguments_missing`.
- [x] Bad `--repo` ⇒ `bad_repo` error.
- [x] `--apply` without project args, without `--status-map`, with partial `--status-map`, with malformed `--status-map` JSON all halt with explicit errors before any mutation API call.
- [x] `skills/README.md` and root `README.md` list the skill.