### PR TITLE
github-project-board-maintenance: tolerate partial GraphQL errors for org owners

### DIFF
--- a/skills/github-project-board-maintenance/scripts/project_board_maintenance.py
+++ b/skills/github-project-board-maintenance/scripts/project_board_maintenance.py
@@ -42,6 +42,14 @@ def gh_auth_ok() -> bool:
 def gh_api_json(args: list[str]) -> tuple[bool, Any, str]:
     rc, out, err = run_gh(["api", *args])
     if rc != 0:
+        # gh exits non-zero for partial GraphQL errors (e.g. user vs org ambiguity)
+        # but still emits a JSON body with a "data" key — try to salvage it.
+        try:
+            parsed = json.loads(out)
+            if isinstance(parsed, dict) and "data" in parsed:
+                return True, parsed, ""
+        except (json.JSONDecodeError, ValueError):
+            pass
         return False, None, (err.strip() or out.strip())[:500]
     try:
         return True, json.loads(out), ""
@@ -184,9 +192,16 @@ def fetch_project_snapshot(
         ok, data, err = gh_api_json(args)
         if not ok:
             return False, {}, err
-        if isinstance(data, dict) and data.get("errors"):
-            return False, {}, json.dumps(data["errors"])[:500]
         d = data.get("data", {}) if isinstance(data, dict) else {}
+        if isinstance(data, dict) and data.get("errors"):
+            # Partial errors (e.g. user-not-found when owner is an org) are tolerated
+            # as long as we can resolve the project from the data that did come back.
+            proj_check = (
+                (d.get("organization") or {}).get("projectV2")
+                or (d.get("user") or {}).get("projectV2")
+            )
+            if not proj_check:
+                return False, {}, json.dumps(data["errors"])[:500]
         proj = (
             (d.get("organization") or {}).get("projectV2")
             or (d.get("user") or {}).get("projectV2")

--- a/skills/github-project-board-maintenance/scripts/project_board_maintenance.py
+++ b/skills/github-project-board-maintenance/scripts/project_board_maintenance.py
@@ -46,7 +46,7 @@ def gh_api_json(args: list[str]) -> tuple[bool, Any, str]:
         # but still emits a JSON body with a "data" key — try to salvage it.
         try:
             parsed = json.loads(out)
-            if isinstance(parsed, dict) and "data" in parsed:
+            if isinstance(parsed, dict) and isinstance(parsed.get("data"), dict):
                 return True, parsed, ""
         except (json.JSONDecodeError, ValueError):
             pass
@@ -192,16 +192,24 @@ def fetch_project_snapshot(
         ok, data, err = gh_api_json(args)
         if not ok:
             return False, {}, err
-        d = data.get("data", {}) if isinstance(data, dict) else {}
+        d = (data.get("data") or {}) if isinstance(data, dict) else {}
         if isinstance(data, dict) and data.get("errors"):
-            # Partial errors (e.g. user-not-found when owner is an org) are tolerated
-            # as long as we can resolve the project from the data that did come back.
+            errors_list = data["errors"]
+            # Only tolerate the known user-not-found error from the dual org+user query.
+            # Any other error (auth, rate-limit, null field resolution, etc.) is fatal.
+            _user_res_re = re.compile(
+                r"Could not resolve to a (User|Organization) with the login of"
+            )
+            non_tolerable = [
+                e for e in errors_list
+                if not (isinstance(e, dict) and _user_res_re.search(e.get("message", "")))
+            ]
             proj_check = (
                 (d.get("organization") or {}).get("projectV2")
                 or (d.get("user") or {}).get("projectV2")
             )
-            if not proj_check:
-                return False, {}, json.dumps(data["errors"])[:500]
+            if non_tolerable or not proj_check:
+                return False, {}, json.dumps(errors_list)[:500]
         proj = (
             (d.get("organization") or {}).get("projectV2")
             or (d.get("user") or {}).get("projectV2")


### PR DESCRIPTION
Closes #93

## Summary

- **`gh_api_json`**: on non-zero exit, attempt to parse stdout as JSON; if a `"data"` key is present, return it as a partial-success so the caller can decide whether the errors are fatal.
- **`fetch_project_snapshot`**: move the `d = data.get("data", {})` extraction before the errors check; tolerate partial errors as long as either the `organization` or `user` node yields a project.

## Root cause

`gh api graphql` exits non-zero whenever the response body includes any `errors` array — even when the query partially succeeded (e.g. `user(login: "uda-lab")` fails because the login is an org, but `organization(login: "uda-lab")` returned the project). The two early-exit checks caused `fetch_project_snapshot` to classify the entire call as `gh_command_failed`, leaving `matched_items` empty and all candidates skipped.

## Validation

```
python3 -m py_compile skills/github-project-board-maintenance/scripts/project_board_maintenance.py
# → syntax OK

python3 scripts/project_board_maintenance.py \
  --repo uda-lab/spread-applicant-ai --since-hours 168 \
  --project-owner uda-lab --project-number 2 \
  --status-field Status --status-map status-map.json --dry-run
# Before patch → errors: [{reason: "gh_command_failed", detail: "Could not resolve to a User with the login of 'uda-lab'"}], matched: 0
# After patch  → errors: [], matched: 11, proposed: 6
# --apply run  → applied: 6, errors: 0
```