### PR TITLE
github-project-board-maintenance: tolerate 'an Organization' in dual-query NOT_FOUND (Closes #95)

### DIFF
--- a/skills/github-project-board-maintenance/scripts/project_board_maintenance.py
+++ b/skills/github-project-board-maintenance/scripts/project_board_maintenance.py
@@ -198,7 +198,7 @@ def fetch_project_snapshot(
             # Only tolerate the known user-not-found error from the dual org+user query.
             # Any other error (auth, rate-limit, null field resolution, etc.) is fatal.
             _user_res_re = re.compile(
-                r"Could not resolve to a (User|Organization) with the login of"
+                r"Could not resolve to an? (User|Organization) with the login of"
             )
             non_tolerable = [
                 e for e in errors_list


### PR DESCRIPTION
## Summary

Fixes #95. The dual org+user GraphQL probe in `fetch_project_snapshot` always returns one `NOT_FOUND` for the arm that does not match the owner type. The tolerance regex at `scripts/project_board_maintenance.py:201` required the article `a `, so it matched `a User` (when owner is an Organization) but missed `an Organization` (when owner is a User). On user-owned Projects this classified the expected error as `non_tolerable`, and the script returned `False` even though `data.user.projectV2` was populated.

Change the article to `an?` so both `a User` and `an Organization` are tolerated. Minimal one-character fix; preserves the original intent of only swallowing the expected dual-query NOT_FOUND.

Closes #95

## Validation

- Syntax check:
  ```
  python3 -m py_compile skills/github-project-board-maintenance/scripts/project_board_maintenance.py
  # OK_COMPILE
  ```
- Regex behavior (inline harness):
  - `"Could not resolve to an Organization with the login of 't-uda'."` → match (was: miss) ✅
  - `"Could not resolve to a User with the login of 'some-org'."` → match ✅
  - `"Could not resolve to a Repository ..."` → no match ✅
  - `"Some other error message"` → no match ✅

## Test plan

- [x] `python3 -m py_compile` passes on the edited script.
- [x] Regex matches both `an Organization` and `a User` forms; non-matching errors stay fatal.