### PR TITLE
Fix #97 squash-merge detection for renamed issue branches

### DIFF
--- a/skills/git-workspace-cleanup/scripts/git_prune_worktrees.py
+++ b/skills/git-workspace-cleanup/scripts/git_prune_worktrees.py
@@ -480,6 +480,10 @@ def issue_branch_prefix(branch: str) -> str | None:
     return match.group(1)
 
 
+def issue_branch_head_search(prefix: str) -> str:
+    return f"head:{prefix}"
+
+
 def gh_list_merged_prs(
     repo: Path,
     owner: str,
@@ -551,7 +555,7 @@ def pr_merged_via_gh(
         prefix = issue_branch_prefix(branch)
         if prefix is not None:
             search_items, error = gh_list_merged_prs(
-                repo, owner, name, base, search=prefix,
+                repo, owner, name, base, search=issue_branch_head_search(prefix),
             )
             if error is not None or search_items is None:
                 return None, error

--- a/skills/git-workspace-cleanup/scripts/git_prune_worktrees.py
+++ b/skills/git-workspace-cleanup/scripts/git_prune_worktrees.py
@@ -14,6 +14,7 @@ import argparse
 import fnmatch
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -41,6 +42,7 @@ DEFAULT_GARBAGE_GLOBS = [
 ]
 
 LARGE_FILE_THRESHOLD = 10 * 1024 * 1024  # 10 MiB
+ISSUE_BRANCH_PREFIX_RE = re.compile(r"^(issue-\d+)(?:$|[-_/])")
 
 
 # ---------------------------------------------------------------------------
@@ -471,6 +473,60 @@ def base_branch_name(base: str) -> str:
     return branch or base
 
 
+def issue_branch_prefix(branch: str) -> str | None:
+    match = ISSUE_BRANCH_PREFIX_RE.match(branch)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def gh_list_merged_prs(
+    repo: Path,
+    owner: str,
+    name: str,
+    base: str,
+    *,
+    head: str | None = None,
+    search: str | None = None,
+) -> tuple[list[dict[str, Any]] | None, dict[str, Any] | None]:
+    command = [
+        "gh", "pr", "list",
+        "--repo", f"{owner}/{name}",
+        "--state", "merged",
+        "--base", base,
+        "--json", "number,headRefName,headRefOid",
+        "--limit", "100",
+    ]
+    if head is not None:
+        command.extend(["--head", head])
+    if search is not None:
+        command.extend(["--search", search])
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=str(repo),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            check=False,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        branch = head if head is not None else search or ""
+        return None, error_record("pr_check_failed", command, str(exc), branch)
+    if completed.returncode != 0:
+        branch = head if head is not None else search or ""
+        return None, error_record("pr_check_failed", command, completed.stderr, branch)
+    try:
+        items = json.loads(completed.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        branch = head if head is not None else search or ""
+        return None, error_record("pr_check_failed", command, str(exc), branch)
+    if not isinstance(items, list):
+        branch = head if head is not None else search or ""
+        return None, error_record("pr_check_failed", command, "invalid gh response", branch)
+    return items, None
+
+
 def pr_merged_via_gh(
     repo: Path,
     owner: str,
@@ -485,32 +541,27 @@ def pr_merged_via_gh(
     Three sub-checks (preserved): exact OID match, tree equality, ancestry.
     Returns (pr_number, error). pr_number=None means no qualifying PR.
     """
-    command = [
-        "gh", "pr", "list",
-        "--repo", f"{owner}/{name}",
-        "--state", "merged",
-        "--head", branch,
-        "--base", base,
-        "--json", "number,headRefOid",
-        "--limit", "20",
-    ]
-    try:
-        completed = subprocess.run(
-            command,
-            cwd=str(repo),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            encoding="utf-8",
-            check=False,
-        )
-    except (FileNotFoundError, OSError) as exc:
-        return None, error_record("pr_check_failed", command, str(exc), branch)
-    if completed.returncode != 0:
-        return None, error_record("pr_check_failed", command, completed.stderr, branch)
-    try:
-        items = json.loads(completed.stdout or "[]")
-    except json.JSONDecodeError as exc:
-        return None, error_record("pr_check_failed", command, str(exc), branch)
+    items, error = gh_list_merged_prs(
+        repo, owner, name, base, head=branch,
+    )
+    if error is not None or items is None:
+        return None, error
+
+    if not items:
+        prefix = issue_branch_prefix(branch)
+        if prefix is not None:
+            search_items, error = gh_list_merged_prs(
+                repo, owner, name, base, search=prefix,
+            )
+            if error is not None or search_items is None:
+                return None, error
+            items = [
+                item
+                for item in search_items
+                if isinstance(item, dict)
+                and issue_branch_prefix(str(item.get("headRefName", ""))) == prefix
+            ]
+
     oid_mismatch_candidates: list[tuple[int, str]] = []
     for item in items:
         if not isinstance(item, dict):

--- a/skills/git-workspace-cleanup/scripts/test_git_prune_worktrees.py
+++ b/skills/git-workspace-cleanup/scripts/test_git_prune_worktrees.py
@@ -531,7 +531,7 @@ class PreservedSafetyModelTests(unittest.TestCase):
             bin_dir = install_fake_gh(
                 root,
                 search_responses={
-                    ("issue-18", "main"): [{
+                    ("head:issue-18", "main"): [{
                         "number": 18,
                         "headRefName": "issue-18-context-harness-guardrails-plan",
                         "headRefOid": oid,

--- a/skills/git-workspace-cleanup/scripts/test_git_prune_worktrees.py
+++ b/skills/git-workspace-cleanup/scripts/test_git_prune_worktrees.py
@@ -36,6 +36,7 @@ def install_fake_gh(
     root: Path,
     responses: dict[tuple[str, str], list[dict[str, object]]] | None = None,
     *,
+    search_responses: dict[tuple[str, str], list[dict[str, object]]] | None = None,
     fail: bool = False,
 ) -> Path:
     bin_dir = root / "fake-bin"
@@ -47,7 +48,13 @@ def install_fake_gh(
         for i, ((head, base), payload) in enumerate(responses.items()):
             data_path = data_dir / f"resp-{i}.json"
             data_path.write_text(json.dumps(payload), encoding="utf-8")
-            index[f"{head}\0{base}"] = str(data_path)
+            index[f"head\0{head}\0{base}"] = str(data_path)
+    if search_responses is not None:
+        offset = len(index)
+        for i, ((search, base), payload) in enumerate(search_responses.items(), start=offset):
+            data_path = data_dir / f"resp-{i}.json"
+            data_path.write_text(json.dumps(payload), encoding="utf-8")
+            index[f"search\0{search}\0{base}"] = str(data_path)
     index_path = data_dir / "index.json"
     index_path.write_text(json.dumps(index), encoding="utf-8")
     script = bin_dir / "gh"
@@ -61,17 +68,24 @@ if args[:1] == ["--version"]:
 if {fail!r}:
     sys.stderr.write("fake gh: simulated failure\\n")
     sys.exit(1)
-head = base = ""
+head = base = search = ""
 i = 0
 while i < len(args):
     if args[i] == "--head" and i + 1 < len(args):
         head = args[i + 1]
+    elif args[i] == "--search" and i + 1 < len(args):
+        search = args[i + 1]
     elif args[i] == "--base" and i + 1 < len(args):
         base = args[i + 1]
     i += 1
 with open({str(index_path)!r}) as fh:
     index = json.load(fh)
-key = head + "\\x00" + base
+if head:
+    key = "head\\x00" + head + "\\x00" + base
+elif search:
+    key = "search\\x00" + search + "\\x00" + base
+else:
+    key = ""
 path = index.get(key)
 if path and os.path.exists(path):
     with open(path) as fh:
@@ -509,6 +523,33 @@ class PreservedSafetyModelTests(unittest.TestCase):
             self.assertEqual(done[0]["reason"], "merged_branch_via_pr")
             self.assertIn("PR #50", done[0]["detail"])
 
+    def test_prefix_search_matches_renamed_issue_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            branch = "issue-18-merge-gate"
+            fixture, oid = self._setup_squash_fixture(root, branch)
+            bin_dir = install_fake_gh(
+                root,
+                search_responses={
+                    ("issue-18", "main"): [{
+                        "number": 18,
+                        "headRefName": "issue-18-context-harness-guardrails-plan",
+                        "headRefOid": oid,
+                    }],
+                },
+            )
+            env = env_without_real_gh(bin_dir)
+            result, data = run_script_v2(
+                fixture.repo, "--yes", "--base", "main", "--no-fetch", env=env,
+            )
+            self.assertEqual(result.returncode, 0, msg=str(data))
+            self.assertFalse(branch_exists(fixture.repo, branch))
+            r = self.repo_data(data)
+            done = [a for a in r["actions"] if a["status"] == "done" and a["branch"] == branch]
+            self.assertEqual(len(done), 1)
+            self.assertEqual(done[0]["reason"], "merged_branch_via_pr")
+            self.assertIn("PR #18", done[0]["detail"])
+
 
 class WorkspaceDiscoveryTests(unittest.TestCase):
     def test_discovers_multiple_repos_under_root(self) -> None:
@@ -614,7 +655,11 @@ class ProcessProbeTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, msg=str(data))
             self.assertTrue(wt.exists())
             r = data["repos"][0]  # type: ignore[index]
-            reasons = {s["reason"] for s in r["skipped"] if s["target"] == str(wt)}
+            reasons = {
+                s["reason"]
+                for s in r["skipped"]
+                if Path(s["target"]).resolve() == wt.resolve()
+            }
             self.assertIn("process_held", reasons)
             probe_states = {p["result"] for p in r["process_probes"]}
             self.assertIn("held", probe_states)
@@ -633,7 +678,11 @@ class ProcessProbeTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0)
             self.assertTrue(wt.exists())
             r = data["repos"][0]  # type: ignore[index]
-            reasons = {s["reason"] for s in r["skipped"] if s["target"] == str(wt)}
+            reasons = {
+                s["reason"]
+                for s in r["skipped"]
+                if Path(s["target"]).resolve() == wt.resolve()
+            }
             self.assertIn("process_probe_unavailable", reasons)
 
     def test_ignore_policy_proceeds_despite_held(self) -> None:


### PR DESCRIPTION
Closes #97

## Summary
- add a merged-PR lookup helper that preserves the exact `--head <local-branch>` query first
- fall back to `issue-<n>` prefix search when the exact query finds no PRs, then filter candidates by `headRefName` before applying the existing OID/tree/ancestry checks
- extend the fake `gh` test harness with `--search` support and add a regression test for renamed issue branches

## Validation
- `python3 -m unittest skills/git-workspace-cleanup/scripts/test_git_prune_worktrees.py`
