### PR TITLE
Add deslop-prose and tighten deslop-history

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Each skill must live at `skills/<skill-name>/SKILL.md`.
 ### Artifact cleanup
 
 - `deslop-history`: clean final user-visible artifacts from accepted decisions or issue/PR discussion by removing historical residue and process framing
+- `deslop-prose`: clean academic or professional prose by removing hype, generic metadiscourse, decorative structure, and claim-evidence mismatch while preserving technical meaning
 
 ### Orchestration
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -26,6 +26,7 @@ Current skills:
 - sot-integrity
 - light-orchestration
 - deslop-history
+- deslop-prose
 - devcontainer-cli
 - github-driven-workflow
 - randomness

--- a/skills/deslop-history/SKILL.md
+++ b/skills/deslop-history/SKILL.md
@@ -25,6 +25,7 @@ Do not use this skill for:
 - historical records, changelogs, postmortems, or audit artifacts where history is required content
 - unresolved design discussions
 - legal, regulatory, or compliance material where provenance must be preserved
+- broad prose polishing when the main problem is inflated, generic, or AI-sounding writing without discussion residue
 
 Do not remove:
 
@@ -59,6 +60,7 @@ Use these categories.
 - `current-state-essential` — current decisions, interfaces, contracts, responsibility splits, active constraints, active assumptions, and operational open issues
 - `operational-rationale` — rationale still needed to prevent misimplementation or misuse
 - `historical-meta-residue` — discussion provenance, superseded alternatives, prior drafts, process notes, defensive explanations, and agent-facing framing
+- `historical-meta-residue` also includes negative definitions that mainly answer an earlier misunderstanding instead of stating the current role directly
 - `nonessential-context` — background that may be interesting but does not change the reader's action
 
 Keep `current-state-essential`.
@@ -81,6 +83,8 @@ Candidates for deletion or rewriting include:
 - "In review ..."
 - "For now" when it reflects discussion timing rather than a real boundary
 - migration or backward-compatibility framing with no current operational effect
+- "This is not X" when it mainly reacts to earlier discussion rather than preventing a likely current misuse
+- internal protocol detail that exists only to coordinate drafting or review
 
 Candidates for retention include:
 
@@ -99,6 +103,10 @@ Candidates for retention include:
 - Remove defensive framing about why the artifact exists.
 - Remove agent-facing process commentary from user-facing outputs.
 - Keep caveats that affect execution, but make them operational.
+- Rewrite negative definitions into positive current-state statements when possible.
+- Keep negative framing only when it prevents a likely misuse by the intended reader.
+- Separate process from structure: describe the actual responsibility boundary, interface, or user model, not the planning discussion that produced it.
+- Replace internal coordination protocols with reader-facing abstractions unless the reader must execute the protocol.
 - Preserve links only when they define current authority, unresolved boundaries, or required follow-up.
 - Do not introduce new decisions, broaden scope, or erase active constraints.
 
@@ -112,6 +120,16 @@ After: Preserve compatibility notes when they affect current behaviour.
 ```text
 Before: This supersedes the earlier direction to include the full discussion.
 After: Include only current decisions and operational constraints.
+```
+
+```text
+Before: This is not intended to replace the existing evaluation framework.
+After: This complements the existing evaluation framework by handling final prose cleanup.
+```
+
+```text
+Before: The 12-tier scoring protocol and 9 failure-mode taxonomy are used to synchronise agent review.
+After: The review uses a structured evaluation framework to identify common failure modes.
 ```
 
 ## Output
@@ -140,9 +158,11 @@ Before finishing, verify:
 - deleting removed text cannot cause likely misimplementation
 - the artifact reads as if written directly in final form
 - open issue references remain only when operationally useful
+- internal review or coordination protocol details are either removed or rewritten for the intended reader
 
 ## Relationship to Other Skills
 
 - Use `sot-integrity` when the artifact's authority or factual grounding must be audited.
 - Use `metaplan` when a plan or spec still needs execution-readiness review.
 - Use `handoff-prompt` when the output is a transfer prompt for another agent.
+- Use `deslop-prose` when the main problem is inflated, generic, or over-polished prose rather than issue-history residue.

--- a/skills/deslop-prose/SKILL.md
+++ b/skills/deslop-prose/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: deslop-prose
+description: Clean academic or professional prose that carries AI-generated residue by removing hype, decorative structure, vague metadiscourse, pseudo-technical phrasing, and claim-evidence mismatch while preserving technical meaning, qualifications, and authorial intent.
+---
+
+# Deslop Prose
+
+Edit final or near-final prose so it says the same thing with higher signal and lower inflation.
+
+Use this when the draft is already directionally correct but reads as generic, over-polished, over-enumerated, or AI-shaped. Do not use it for factual verification, source-of-truth adjudication, or discussion-history cleanup.
+
+## Use when
+
+Use this skill when:
+
+- academic or professional prose sounds inflated, generic, or mechanically polished
+- claims are broader or stronger than the evidence stated nearby
+- decorative structure or metadiscourse is displacing content
+- terminology sounds improvised when an established term would be clearer
+
+## Do not use
+
+Do not use this skill for:
+
+- issue, PR, or prior-draft residue cleanup where the main problem is discussion provenance
+- source-of-truth auditing, factual verification, or citation checking
+- legal or policy text where rhetorical softening could change meaning
+- drafts that still need architectural or substantive decisions
+
+Use `deslop-history` when the artifact leaks process history, superseded alternatives, or agent-facing framing.
+
+## Inputs
+
+Gather or infer these before editing:
+
+- `artifact` — the prose to clean
+- `intended_reader` — who must read or act on it
+- `artifact_type` — paper, memo, report, proposal, README, summary, or similar
+- `technical_terms` — terms that should remain stable
+- `evidence_scope` — the facts, results, citations, or qualifications that bound the claims
+
+Ask only when rewriting could blur a technical term, scope boundary, or required qualification.
+
+## Procedure
+
+1. Identify the intended reader, artifact type, and evidence scope.
+2. Mark sentences where style is carrying more weight than content.
+3. Tighten claims so their strength matches the stated support.
+4. Remove decorative structure, generic metadiscourse, and pseudo-technical inflation.
+5. Rewrite with stable terminology and direct claims.
+6. Check that qualifications, citations, definitions, and authorial intent still hold.
+
+## Target Patterns
+
+- `hype-inflation` — unsupported importance claims such as "transformative" or "pivotal"
+- `enumeration-inflation` — decorative lists that imply coverage without support
+- `generic-metadiscourse` — scaffolding like "It is important to note that"
+- `framework-inflation` — grand labels such as "broader landscape" or "holistic framework" without a concrete framework
+- `methodological-theatre` — vague rigor language where a concrete method should be named
+- `vague-significance` — "valuable insights" or "important implications" without the concrete insight or implication
+- `defensive-negative-framing` — "This is not X" when a positive statement would be clearer
+- `unstable-terminology` — unusual paraphrases that obscure standard concepts
+- `hyphen-chain-pseudo-terms` — long ad hoc compounds that sound technical without adding precision
+- `formulaic-symmetry` — repeated structures like "not only X but also Y" when the contrast adds no value
+- `claim-evidence-mismatch` — certainty, breadth, or importance exceeding the support in the text
+
+## Rewrite Rules
+
+- Prefer concrete contribution claims over broad importance claims.
+- Prefer one supported dimension over a long decorative list.
+- Start with the claim, not the sentence-level announcement of the claim.
+- Name the actual method, evidence, dataset, theorem, metric, proof step, or procedure when known.
+- Preserve necessary hedging, qualifications, citations, notation, and scope boundaries.
+- Preserve established technical terms; do not paraphrase for freshness.
+- Rewrite long ad hoc hyphenated compounds as ordinary noun phrases unless the compound is standard.
+- Keep negative framing only when it prevents a likely misuse.
+- Do not turn precise prose into smooth but lower-density prose.
+
+Minimal examples:
+
+```text
+Before: This transformative framework provides valuable insights into a broad landscape of practical applications.
+After: This framework identifies the practical conditions under which the method applies.
+```
+
+```text
+Before: We systematically and rigorously analyse the method across efficiency, scalability, robustness, interpretability, and applicability.
+After: We evaluate runtime and robustness on the reported benchmarks.
+```
+
+## Output
+
+If the user asks to edit a file, apply the rewrite directly. If the user asks for cleanup text only, return the revised prose without an audit log.
+
+When the user asks for review before editing, provide:
+
+- the inferred reader and artifact type
+- the main inflation patterns present
+- the cleaned prose
+
+When editing repository files:
+
+- modify only the target artifact or directly required index entries
+- keep the diff focused on prose cleanup guidance
+- do not introduce style taxonomies beyond what the artifact needs
+
+## Quality Check
+
+Before finishing, verify:
+
+- the claim strength matches the evidence actually present
+- decorative enumeration and generic metadiscourse are gone
+- technical meaning, qualifications, and terminology remain intact
+- the prose sounds more direct, not more impressive
+- `deslop-history` would not be the more appropriate skill
+
+## Relationship to Other Skills
+
+- Use `deslop-history` when the main problem is discussion provenance, prior-draft residue, or process framing.
+- Use `sot-integrity` when authority, factual grounding, or trust scope must be audited.
+- Use `textlint-cli` for deterministic lint checks, not context-sensitive prose judgment.


### PR DESCRIPTION
Closes #99
Closes #100

## Summary
- refine `deslop-history` without broadening it into a monolithic cleanup skill
- add `deslop-prose` as a focused sibling for academic and professional prose cleanup
- update skill indexes in `README.md` and `skills/README.md`

## Validation
- `git diff --check`
  - pass

## Notes
- no unchecked task boxes remain in this PR body