### PR TITLE
Fix growing-agents-md section pruning guidance

### DIFF
--- a/skills/growing-agents-md/SKILL.md
+++ b/skills/growing-agents-md/SKILL.md
@@ -14,7 +14,7 @@ Use it when:
 - the current task changes durable commands, architecture, or workflow rules
 - the file became generic, bloated, or stale enough to prune
 
-The bundled script is the source of truth for scaffold shape, guard comments, placeholder rules, section rendering, and the counted-line budget:
+The bundled script is the source of truth for scaffold shape, structural guard comments, placeholder rules, section rendering, and the counted-line budget:
 
 ```sh
 python3 scripts/growing_agents_md.py <command>
@@ -25,8 +25,10 @@ python3 scripts/growing_agents_md.py <command>
 1. Run `init` when `AGENTS.md` is missing. This writes the canonical scaffold only.
 2. Run `lint` before editing an existing file. If lint fails, do not guess repairs outside the canonical schema.
 3. Gather only stable, repo-specific facts worth preserving in durable agent guidance.
-4. Run `apply` with structured JSON input to replace whole sections deterministically.
-5. Review the result for repo-specific quality, then keep moving. Do not turn `AGENTS.md` into a changelog.
+4. Before `apply`, decide which replaceable sections should be omitted. Pass `[]` for content that is inferable, redundant, or not durable.
+5. Run `apply` with structured JSON input to replace or remove whole sections deterministically.
+6. Review the rendered file. If a populated section merely restates README, package metadata, or obvious repo layout, rerun `apply` with that section empty or missing.
+7. Keep moving. Do not turn `AGENTS.md` into a changelog.
 
 ## Commands
 
@@ -47,7 +49,7 @@ python3 scripts/growing_agents_md.py apply --input agents.json
 }
 ```
 
-Missing or empty arrays remove that replaceable section. The script hard-fails on non-canonical structure, placeholder leftovers, forbidden catch-all headings, or counted-line budget overflow.
+Missing or empty arrays remove that replaceable section. This is the canonical way to prune low-value categories. The script hard-fails on non-canonical structure, placeholder leftovers, forbidden catch-all headings, or counted-line budget overflow.
 
 ## Content policy
 

--- a/skills/growing-agents-md/scripts/growing_agents_md.py
+++ b/skills/growing-agents-md/scripts/growing_agents_md.py
@@ -33,7 +33,8 @@ FORBIDDEN_HEADINGS = {"notes", "misc", "context", "important context", "other"}
 class ReplaceableSection:
     key: str
     heading: str
-    comment: str
+    placeholder_comment: str
+    content_comment: str
     placeholder_lines: tuple[str, ...]
     kind: str
 
@@ -42,28 +43,32 @@ REPLACEABLE_SECTIONS = (
     ReplaceableSection(
         key="project_overview",
         heading="Project Overview",
-        comment="<!-- Replace this section in-place. Remove the placeholder line once filled. -->",
+        placeholder_comment="<!-- Replace this section in-place. Remove the placeholder line once filled. -->",
+        content_comment="<!-- Managed section: update with apply input, or omit/pass [] to remove. -->",
         placeholder_lines=("- [TODO: add stable repo overview]",),
         kind="bullets",
     ),
     ReplaceableSection(
         key="commands",
         heading="Commands",
-        comment="<!-- Replace this section in-place. Remove the placeholder block once filled. -->",
+        placeholder_comment="<!-- Replace this section in-place. Remove the placeholder block once filled. -->",
+        content_comment="<!-- Managed section: update with apply input, or omit/pass [] to remove. -->",
         placeholder_lines=("~~~sh", "# [TODO: add only high-value commands]", "~~~"),
         kind="commands",
     ),
     ReplaceableSection(
         key="code_conventions",
         heading="Code Conventions",
-        comment="<!-- Replace this section in-place. Remove the placeholder line once filled. -->",
+        placeholder_comment="<!-- Replace this section in-place. Remove the placeholder line once filled. -->",
+        content_comment="<!-- Managed section: update with apply input, or omit/pass [] to remove. -->",
         placeholder_lines=("- [TODO: add only non-obvious repo-specific conventions]",),
         kind="bullets",
     ),
     ReplaceableSection(
         key="architecture",
         heading="Architecture",
-        comment="<!-- Replace this section in-place. Remove the placeholder line once filled. -->",
+        placeholder_comment="<!-- Replace this section in-place. Remove the placeholder line once filled. -->",
+        content_comment="<!-- Managed section: update with apply input, or omit/pass [] to remove. -->",
         placeholder_lines=("- [TODO: add only stable architecture boundaries or entry points]",),
         kind="bullets",
     ),
@@ -259,13 +264,21 @@ def validate_section_body(
         return []
 
     section = SECTION_BY_HEADING[heading]
-    expected_prefix = ["", section.comment]
-    if body[:2] != expected_prefix:
+    if len(body) < 2 or body[0] != "":
         return [f"{heading} must keep its canonical guard comment"]
     content = body[2:]
     if not content:
         return [f"{heading} must contain placeholder content or final content"]
-    return validate_content_lines(section, content, allow_placeholder=True, context=heading)
+    is_placeholder = content == list(section.placeholder_lines)
+    content_errors = validate_content_lines(section, content, allow_placeholder=True, context=heading)
+    if content_errors:
+        return content_errors
+    expected_comment = section.placeholder_comment if is_placeholder else section.content_comment
+    if body[1] != expected_comment:
+        if not is_placeholder and body[1] == section.placeholder_comment:
+            return [f"{heading} must use the populated-section guard comment"]
+        return [f"{heading} must keep its canonical guard comment"]
+    return []
 
 
 def validate_content_lines(
@@ -373,7 +386,12 @@ def render_document(section_content: dict[str, list[str] | None]) -> str:
         content = section_content[section.key]
         if not content:
             continue
-        lines.extend([f"## {section.heading}", "", section.comment, *content, ""])
+        comment = (
+            section.placeholder_comment
+            if content == list(section.placeholder_lines)
+            else section.content_comment
+        )
+        lines.extend([f"## {section.heading}", "", comment, *content, ""])
     lines.extend([f"## {MAINTENANCE_HEADING}", "", MAINTENANCE_GUARD, *MAINTENANCE_LINES])
     return "\n".join(lines) + "\n"
 

--- a/skills/growing-agents-md/scripts/test_growing_agents_md.py
+++ b/skills/growing-agents-md/scripts/test_growing_agents_md.py
@@ -50,6 +50,7 @@ EXPECTED_SCAFFOLD = """# Agent Guidelines
 - Update commands and architecture when workflows change.
 - Keep durable rules here; move detail to dedicated docs.
 """
+POPULATED_GUARD = "<!-- Managed section: update with apply input, or omit/pass [] to remove. -->"
 
 
 def run_script(
@@ -144,7 +145,9 @@ class GrowingAgentsMdTests(unittest.TestCase):
             self.assertIn("## Commands", text)
             self.assertIn("## Code Conventions", text)
             self.assertIn("## Architecture", text)
+            self.assertIn(POPULATED_GUARD, text)
             self.assertNotIn("[TODO:", text)
+            self.assertNotIn("Remove the placeholder", text)
             self.assertIn("## Maintenance Notes", text)
             self.assertEqual(run_script(root, "lint").returncode, 0)
 
@@ -172,6 +175,49 @@ class GrowingAgentsMdTests(unittest.TestCase):
             self.assertNotIn("## Commands", text)
             self.assertNotIn("## Code Conventions", text)
             self.assertNotIn("## Architecture", text)
+
+    def test_minimal_commands_and_architecture_file_is_lint_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            run_script(root, "init")
+
+            result = run_script(
+                root,
+                "apply",
+                "--input",
+                "-",
+                input_text=json.dumps(
+                    {
+                        "commands": ["~~~sh", "python3 -m unittest", "~~~"],
+                        "architecture": ["- Keep deterministic scaffold logic in bundled scripts."],
+                    }
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0)
+            text = (root / "AGENTS.md").read_text(encoding="utf-8")
+            self.assertNotIn("## Project Overview", text)
+            self.assertIn("## Commands", text)
+            self.assertNotIn("## Code Conventions", text)
+            self.assertIn("## Architecture", text)
+            self.assertNotIn("Remove the placeholder", text)
+            self.assertEqual(run_script(root, "lint").returncode, 0)
+
+    def test_lint_rejects_populated_sections_with_placeholder_guard(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write(
+                root / "AGENTS.md",
+                EXPECTED_SCAFFOLD.replace(
+                    "- [TODO: add stable repo overview]",
+                    "- Stable repo summary.",
+                ),
+            )
+
+            result = run_script(root, "lint", check=False)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Project Overview must use the populated-section guard comment", result.stderr)
 
     def test_lint_fails_when_placeholder_tokens_remain_in_populated_section(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Closes #104

## Summary

- Make section pruning explicit before and after apply in the growing-agents-md workflow.
- Render populated replaceable sections with a structural guard comment instead of placeholder-removal wording.
- Add regression coverage for populated guard comments and minimal pruned AGENTS.md output.

## Validation

- git diff --check: passed
- python3 -m unittest skills/growing-agents-md/scripts/test_growing_agents_md.py: passed, 13 tests
- python3 -m unittest skills/growing-agents-md/scripts/test_growing_agents_md.py skills/git-workspace-cleanup/scripts/test_git_prune_worktrees.py: passed, 41 tests