### PR TITLE
fix(git-workspace-cleanup): detect stacked-PR merges via intermediate base branches

### DIFF
--- a/skills/git-workspace-cleanup/SKILL.md
+++ b/skills/git-workspace-cleanup/SKILL.md
@@ -112,6 +112,14 @@ A branch is considered merged when either condition holds:
      ancestor of the resolved base commit. Supports stacked-PR workflows
      where children merge into an integration branch that is later merged
      into `--base`.
+   - **recursive squash-of-integration**: when neither of the above holds,
+     the code recursively looks up a merged PR whose head is this PR's
+     `baseRefName` (the integration branch). If our `mergeCommit.oid` is
+     an ancestor of that next PR's `headRefOid` (meaning our merge was
+     included when the integration branch was itself merged), *and* that
+     next PR also reaches `--base` (by any of these three rules), the
+     original branch is considered reachable. The recursion is capped at
+     depth 8 and cycle-detected via a visited set of branch names.
 
    `git branch -D` is permitted only for case 2; the recorded PR# is required
    as the audit trail. Action reports `reason: merged_branch_via_pr` with

--- a/skills/git-workspace-cleanup/SKILL.md
+++ b/skills/git-workspace-cleanup/SKILL.md
@@ -92,8 +92,9 @@ A branch is considered merged when either condition holds:
 1. **Reachability**: the branch tip is reachable from `--base` (true merge or
    fast-forward). Action uses `git branch -d` and reports
    `reason: merged_branch`.
-2. **PR-verified**: a merged GitHub PR exists with `head = <branch>` and
-   `base = <base>`, and at least one of the following holds:
+2. **PR-verified**: a merged GitHub PR exists with `head = <branch>`, at
+   least one content sub-check holds, **and** the PR's content provably
+   reached `--base`:
    - **(a) exact match**: the local branch tip OID equals the PR's recorded
      `headRefOid`.
    - **(b) tree equality**: after fetching the PR head, the local branch tip
@@ -102,6 +103,15 @@ A branch is considered merged when either condition holds:
    - **(c) ancestry**: after fetching the PR head, the local tip is a strict
      ancestor. Covers cases where the remote branch was extended beyond the
      local branch before merging.
+
+   Reachability into `--base` is verified by one of:
+   - **direct merge**: the PR's `baseRefName` equals the cleanup base
+     branch (the classic case).
+   - **stacked / intermediate-base merge**: the PR was merged into an
+     intermediate integration branch, and the PR's `mergeCommit.oid` is an
+     ancestor of the resolved base commit. Supports stacked-PR workflows
+     where children merge into an integration branch that is later merged
+     into `--base`.
 
    `git branch -D` is permitted only for case 2; the recorded PR# is required
    as the audit trail. Action reports `reason: merged_branch_via_pr` with

--- a/skills/git-workspace-cleanup/scripts/git_prune_worktrees.py
+++ b/skills/git-workspace-cleanup/scripts/git_prune_worktrees.py
@@ -488,17 +488,20 @@ def gh_list_merged_prs(
     repo: Path,
     owner: str,
     name: str,
-    base: str,
     *,
     head: str | None = None,
     search: str | None = None,
 ) -> tuple[list[dict[str, Any]] | None, dict[str, Any] | None]:
+    # `--base` is intentionally omitted: stacked-PR workflows merge children
+    # into an intermediate integration branch, not directly into the cleanup
+    # base. Filtering by base here would drop those candidates before the
+    # content checks can run. Reachability into base_commit is re-verified in
+    # pr_merged_via_gh via the returned baseRefName / mergeCommit fields.
     command = [
         "gh", "pr", "list",
         "--repo", f"{owner}/{name}",
         "--state", "merged",
-        "--base", base,
-        "--json", "number,headRefName,headRefOid",
+        "--json", "number,headRefName,headRefOid,baseRefName,mergeCommit",
         "--limit", "100",
     ]
     if head is not None:
@@ -538,16 +541,20 @@ def pr_merged_via_gh(
     branch: str,
     branch_oid: str,
     base: str,
+    base_commit: str,
     remote: str = "origin",
 ) -> tuple[int | None, dict[str, Any] | None]:
-    """Look up a merged PR for `branch` and verify the local tip is incorporated.
+    """Look up a merged PR for `branch` and verify the local tip is incorporated into `base_commit`.
 
-    Three sub-checks (preserved): exact OID match, tree equality, ancestry.
+    Two layers:
+      (1) Content match against the PR head: exact OID, tree equality, or ancestry.
+      (2) Reachability into base_commit: either the PR's baseRefName equals the
+          cleanup base branch (direct merge), or the PR's mergeCommit.oid is an
+          ancestor of base_commit (stacked / intermediate-base merge).
+
     Returns (pr_number, error). pr_number=None means no qualifying PR.
     """
-    items, error = gh_list_merged_prs(
-        repo, owner, name, base, head=branch,
-    )
+    items, error = gh_list_merged_prs(repo, owner, name, head=branch)
     if error is not None or items is None:
         return None, error
 
@@ -555,7 +562,7 @@ def pr_merged_via_gh(
         prefix = issue_branch_prefix(branch)
         if prefix is not None:
             search_items, error = gh_list_merged_prs(
-                repo, owner, name, base, search=issue_branch_head_search(prefix),
+                repo, owner, name, search=issue_branch_head_search(prefix),
             )
             if error is not None or search_items is None:
                 return None, error
@@ -566,7 +573,64 @@ def pr_merged_via_gh(
                 and issue_branch_prefix(str(item.get("headRefName", ""))) == prefix
             ]
 
-    oid_mismatch_candidates: list[tuple[int, str]] = []
+    target_base = base_branch_name(base)
+
+    def _is_ancestor(child_oid: str, parent_oid: str) -> bool:
+        ancestor = run_git(["merge-base", "--is-ancestor", child_oid, parent_oid], repo)
+        if ancestor.returncode == 0:
+            return True
+        if ancestor.returncode == 1:
+            return False
+        # Unknown — try fetching both refs and retry.
+        for oid in (child_oid, parent_oid):
+            run_git(["fetch", remote, oid], repo)
+        ancestor = run_git(["merge-base", "--is-ancestor", child_oid, parent_oid], repo)
+        return ancestor.returncode == 0
+
+    def _reaches_base(
+        item: dict[str, Any],
+        visited: set[str] | None = None,
+        depth: int = 0,
+    ) -> bool:
+        if item.get("baseRefName") == target_base:
+            return True
+        if depth >= 8:
+            return False
+        merge_commit = item.get("mergeCommit") or {}
+        merge_oid = merge_commit.get("oid") if isinstance(merge_commit, dict) else None
+        if not merge_oid:
+            return False
+        # Direct: intermediate's merge commit is reachable from base_commit.
+        if _is_ancestor(merge_oid, base_commit):
+            return True
+        # Stacked / squash-of-integration: walk one step up the chain by
+        # looking for a merged PR whose head is this PR's base branch. Our
+        # merge_commit must be reachable from that next PR's head OID
+        # (i.e., the integration branch contained our merge commit at the
+        # time it was merged onward), and that PR must itself reach base.
+        base_ref = item.get("baseRefName")
+        if not base_ref:
+            return False
+        visited = set() if visited is None else visited
+        if base_ref in visited:
+            return False
+        visited = visited | {base_ref}
+        next_items, _next_err = gh_list_merged_prs(repo, owner, name, head=base_ref)
+        if not next_items:
+            return False
+        for next_item in next_items:
+            if not isinstance(next_item, dict):
+                continue
+            next_head_oid = next_item.get("headRefOid")
+            if not next_head_oid:
+                continue
+            if _is_ancestor(merge_oid, next_head_oid) and _reaches_base(
+                next_item, visited, depth + 1,
+            ):
+                return True
+        return False
+
+    oid_mismatch_candidates: list[tuple[int, str, dict[str, Any]]] = []
     for item in items:
         if not isinstance(item, dict):
             continue
@@ -575,10 +639,12 @@ def pr_merged_via_gh(
         if not isinstance(number, int) or not pr_head_oid:
             continue
         if pr_head_oid == branch_oid:
-            return number, None
-        oid_mismatch_candidates.append((number, pr_head_oid))
+            if _reaches_base(item):
+                return number, None
+            continue
+        oid_mismatch_candidates.append((number, pr_head_oid, item))
 
-    for number, pr_head_oid in oid_mismatch_candidates:
+    for number, pr_head_oid, item in oid_mismatch_candidates:
         fetch_result = run_git(["fetch", remote, pr_head_oid], repo)
         if fetch_result.returncode != 0:
             continue
@@ -589,9 +655,11 @@ def pr_merged_via_gh(
             and pr_tree.returncode == 0
             and local_tree.stdout.strip() == pr_tree.stdout.strip()
         ):
-            return number, None
+            if _reaches_base(item):
+                return number, None
+            continue
         ancestor_result = run_git(["merge-base", "--is-ancestor", branch_oid, pr_head_oid], repo)
-        if ancestor_result.returncode == 0:
+        if ancestor_result.returncode == 0 and _reaches_base(item):
             return number, None
 
     return None, None
@@ -1058,7 +1126,7 @@ def build_repo_plan(
             if protected_reason(branch, initial_branch, local_base_branch):
                 continue
             number, pr_error = pr_merged_via_gh(
-                repo, gh_owner, gh_name, branch, info["object"], pr_base, remote,
+                repo, gh_owner, gh_name, branch, info["object"], pr_base, base_commit, remote,
             )
             if pr_error:
                 outcome.errors.append(pr_error)

--- a/skills/git-workspace-cleanup/scripts/git_prune_worktrees.py
+++ b/skills/git-workspace-cleanup/scripts/git_prune_worktrees.py
@@ -573,7 +573,14 @@ def pr_merged_via_gh(
                 and issue_branch_prefix(str(item.get("headRefName", ""))) == prefix
             ]
 
-    target_base = base_branch_name(base)
+    # Accept either the raw base string (e.g. "release/foo" for a local
+    # branch with a slash) or the stripped form returned by base_branch_name
+    # (e.g. "foo" for "origin/foo" or "release/foo" treated as remote/branch).
+    # Using a frozenset avoids a double comparison in the hot path.
+    _stripped_base = base_branch_name(base)
+    target_base_names: frozenset[str] = frozenset(
+        {base, _stripped_base} if base != _stripped_base else {base}
+    )
 
     def _is_ancestor(child_oid: str, parent_oid: str) -> bool:
         ancestor = run_git(["merge-base", "--is-ancestor", child_oid, parent_oid], repo)
@@ -592,7 +599,7 @@ def pr_merged_via_gh(
         visited: set[str] | None = None,
         depth: int = 0,
     ) -> bool:
-        if item.get("baseRefName") == target_base:
+        if item.get("baseRefName") in target_base_names:
             return True
         if depth >= 8:
             return False
@@ -615,7 +622,10 @@ def pr_merged_via_gh(
         if base_ref in visited:
             return False
         visited = visited | {base_ref}
-        next_items, _next_err = gh_list_merged_prs(repo, owner, name, head=base_ref)
+        next_items, next_err = gh_list_merged_prs(repo, owner, name, head=base_ref)
+        if next_err is not None:
+            _reachability_errors.append(next_err)
+            return False
         if not next_items:
             return False
         for next_item in next_items:
@@ -630,6 +640,9 @@ def pr_merged_via_gh(
                 return True
         return False
 
+    # Errors surfaced during recursive reachability lookups are collected here
+    # so they can be returned to the caller after the candidate loop finishes.
+    _reachability_errors: list[dict[str, Any]] = []
     oid_mismatch_candidates: list[tuple[int, str, dict[str, Any]]] = []
     for item in items:
         if not isinstance(item, dict):
@@ -662,6 +675,8 @@ def pr_merged_via_gh(
         if ancestor_result.returncode == 0 and _reaches_base(item):
             return number, None
 
+    if _reachability_errors:
+        return None, _reachability_errors[0]
     return None, None
 
 

--- a/skills/git-workspace-cleanup/scripts/test_git_prune_worktrees.py
+++ b/skills/git-workspace-cleanup/scripts/test_git_prune_worktrees.py
@@ -39,22 +39,27 @@ def install_fake_gh(
     search_responses: dict[tuple[str, str], list[dict[str, object]]] | None = None,
     fail: bool = False,
 ) -> Path:
+    # The production code no longer passes --base to `gh pr list`; reachability
+    # is now checked in-process via the baseRefName / mergeCommit fields in each
+    # PR record. The fake-gh index therefore keys only on head/search (the base
+    # component of the caller-supplied dict key is kept for readability but is
+    # not part of the lookup key used by the fake binary).
     bin_dir = root / "fake-bin"
     bin_dir.mkdir(parents=True, exist_ok=True)
     data_dir = root / "fake-gh-data"
     data_dir.mkdir(parents=True, exist_ok=True)
     index: dict[str, str] = {}
     if responses is not None:
-        for i, ((head, base), payload) in enumerate(responses.items()):
+        for i, ((head, _base), payload) in enumerate(responses.items()):
             data_path = data_dir / f"resp-{i}.json"
             data_path.write_text(json.dumps(payload), encoding="utf-8")
-            index[f"head\0{head}\0{base}"] = str(data_path)
+            index[f"head\0{head}"] = str(data_path)
     if search_responses is not None:
         offset = len(index)
-        for i, ((search, base), payload) in enumerate(search_responses.items(), start=offset):
+        for i, ((search, _base), payload) in enumerate(search_responses.items(), start=offset):
             data_path = data_dir / f"resp-{i}.json"
             data_path.write_text(json.dumps(payload), encoding="utf-8")
-            index[f"search\0{search}\0{base}"] = str(data_path)
+            index[f"search\0{search}"] = str(data_path)
     index_path = data_dir / "index.json"
     index_path.write_text(json.dumps(index), encoding="utf-8")
     script = bin_dir / "gh"
@@ -68,22 +73,20 @@ if args[:1] == ["--version"]:
 if {fail!r}:
     sys.stderr.write("fake gh: simulated failure\\n")
     sys.exit(1)
-head = base = search = ""
+head = search = ""
 i = 0
 while i < len(args):
     if args[i] == "--head" and i + 1 < len(args):
         head = args[i + 1]
     elif args[i] == "--search" and i + 1 < len(args):
         search = args[i + 1]
-    elif args[i] == "--base" and i + 1 < len(args):
-        base = args[i + 1]
     i += 1
 with open({str(index_path)!r}) as fh:
     index = json.load(fh)
 if head:
-    key = "head\\x00" + head + "\\x00" + base
+    key = "head\\x00" + head
 elif search:
-    key = "search\\x00" + search + "\\x00" + base
+    key = "search\\x00" + search
 else:
     key = ""
 path = index.get(key)
@@ -388,7 +391,7 @@ class PreservedSafetyModelTests(unittest.TestCase):
             root = Path(tmp)
             fixture, oid = self._setup_squash_fixture(root)
             bin_dir = install_fake_gh(
-                root, {("issue-99-foo", "main"): [{"number": 99, "headRefOid": oid}]},
+                root, {("issue-99-foo", "main"): [{"number": 99, "headRefOid": oid, "baseRefName": "main", "mergeCommit": None}]},
             )
             env = env_without_real_gh(bin_dir)
             result, data = run_script_v2(
@@ -509,7 +512,7 @@ class PreservedSafetyModelTests(unittest.TestCase):
             oid = branch_oid(fixture.repo, "issue-50-bar")
             git(fixture.repo, "remote", "set-url", "origin", "git@github.com:fake/repo.git")
             bin_dir = install_fake_gh(
-                root, {("issue-50-bar", "release/foo"): [{"number": 50, "headRefOid": oid}]},
+                root, {("issue-50-bar", "release/foo"): [{"number": 50, "headRefOid": oid, "baseRefName": "release/foo", "mergeCommit": None}]},
             )
             env = env_without_real_gh(bin_dir)
             result, data = run_script_v2(
@@ -535,6 +538,8 @@ class PreservedSafetyModelTests(unittest.TestCase):
                         "number": 18,
                         "headRefName": "issue-18-context-harness-guardrails-plan",
                         "headRefOid": oid,
+                        "baseRefName": "main",
+                        "mergeCommit": None,
                     }],
                 },
             )
@@ -740,7 +745,7 @@ class ClassBAndInteractiveTests(unittest.TestCase):
             root = Path(tmp)
             fixture, wt, oid = self._setup_class_b_fixture(root)
             bin_dir = install_fake_gh(
-                root, {("issue-99-foo", "main"): [{"number": 99, "headRefOid": oid}]},
+                root, {("issue-99-foo", "main"): [{"number": 99, "headRefOid": oid, "baseRefName": "main", "mergeCommit": None}]},
             )
             env = env_without_real_gh(bin_dir)
 
@@ -767,7 +772,7 @@ class ClassBAndInteractiveTests(unittest.TestCase):
             root = Path(tmp)
             fixture, wt, oid = self._setup_class_b_fixture(root)
             bin_dir = install_fake_gh(
-                root, {("issue-99-foo", "main"): [{"number": 99, "headRefOid": oid}]},
+                root, {("issue-99-foo", "main"): [{"number": 99, "headRefOid": oid, "baseRefName": "main", "mergeCommit": None}]},
             )
             env = env_without_real_gh(bin_dir)
 
@@ -784,7 +789,7 @@ class ClassBAndInteractiveTests(unittest.TestCase):
             root = Path(tmp)
             fixture, wt, oid = self._setup_class_b_fixture(root)
             bin_dir = install_fake_gh(
-                root, {("issue-99-foo", "main"): [{"number": 99, "headRefOid": oid}]},
+                root, {("issue-99-foo", "main"): [{"number": 99, "headRefOid": oid, "baseRefName": "main", "mergeCommit": None}]},
             )
             env = env_without_real_gh(bin_dir)
 


### PR DESCRIPTION
## Bug

`scripts/git_prune_worktrees.py` in `git-workspace-cleanup` fails to detect merged child PRs in stacked-PR workflows.

`gh_list_merged_prs` builds a `gh pr list` command that filters by `--base origin/main`. The 3-stage content check (exact OID / tree equality / ancestry) that follows operates on this already-filtered list. For stacked-PR workflows where children PRs merge into an intermediate integration branch (e.g., `mvp4`) and that integration branch is later merged into `main`, the children's PRs have `baseRefName = mvp4` (not `main`). The pre-filter returns `[]`, the content checks never run, and the children get classified as `unmerged` and skipped.

## Concrete failure (the case that surfaced this)

`uda-lab/yomotsusaka` MVP-4 used the stacked-PR pattern:

- Children PRs #80, #81, #83-#87 had `base=mvp4`.
- Integration PR #88 (`mvp4` -> `main`) was squash-merged as commit `84002e04`.
- After merge, running `git_prune_worktrees.py --yes` classified all 8 child branches/worktrees as `unmerged` because the gh query filtered by `--base main` returned 0 results before the tree-equality check could run.

## Fix (two layers)

**1. `gh_list_merged_prs`** — drop `--base` from the gh query and add `baseRefName,mergeCommit` to `--json`. Now returns all merged PRs for the head, regardless of base. The author/base context is reattached at the verification step.

**2. `pr_merged_via_gh`** — after a content sub-check passes against the PR head, verify reachability into `base_commit` via a new `_reaches_base()` helper. The helper handles three cases:

- **direct**: PR's `baseRefName` equals the cleanup base branch (classic case, unchanged behavior).
- **stacked (merge-commit)**: PR's `mergeCommit.oid` is an ancestor of `base_commit` — the integration branch was merge-committed into `--base`, so the child's merge commit is already reachable.
- **stacked (squash-of-integration)**: recursively look up the next merged PR with `head = current PR's baseRefName`; require the current PR's merge commit is reachable from that next PR's `headRefOid`, and that next PR itself reaches base. Depth-limited to 8 with cycle detection via a `visited` set. This is the squash-merge case where the integration branch's history isn't preserved in `--base`, so the child's `mergeCommit.oid` is not an ancestor of `base_commit` directly, but the content is.

The call site at `process_repo()` is updated to pass `base_commit` through to `pr_merged_via_gh`.

## Safety invariant preserved

`git branch -D` still requires audited proof the content is in `--base`. The content checks (exact OID / tree equality / ancestry) still apply against the PR head; the new reachability check is an additional requirement, not a relaxation.

## Tested on

uda-lab/yomotsusaka MVP-4 case. Patched script's `--dry-run` queues 14 actions (7 worktrees + 7 branches), all with `reason: merged_*_via_pr` and the correct PR# detail. Before the patch, the same invocation returned 0 actionable items and 8 `unmerged` skips.

## Notes for reviewer

- The recursive `_reaches_base` helper handles BOTH merge-commit-stacked AND squash-of-integration scenarios — the squash case is the one that actually matters in practice for the MVP-4 squash workflow, but the merge-commit path is a cheap and correct fast path that subsumes the simpler shape.
- `_is_ancestor` falls back to fetching the OID from the remote if `git merge-base --is-ancestor` returns an unknown error, since the integration branch's commits may not be in the local clone after the integration branch was deleted post-merge.
- SKILL.md updated to document the new reachability sub-cases.