### PR TITLE
feat(github-driven-workflow): add experimental augment review route with owner-scoped availability guard

### DIFF
--- a/skills/github-driven-workflow/README.md
+++ b/skills/github-driven-workflow/README.md
@@ -10,8 +10,28 @@ Default implementation of §7 review acquisition. Reviewer-neutral by design: wh
 |------|--------|--------|
 | `copilot` | Assigns the `copilot-pull-request-reviewer[bot]` reviewer to the PR. | `route: copilot (dispatched)` |
 | `codex`   | Posts an `@codex please review this PR` comment on the PR.            | `route: codex (dispatched)` |
+| `augment` | Posts an `auggie review` comment on the PR (Augment manual trigger). **Experimental. Explicit-only** — never added to the random pool. Requires `AUGMENT_REVIEW_ENABLED_OWNERS` guard (see below). | `route: augment (dispatched)` |
 
-Both routes are asynchronous: stdout reports only that a request was *dispatched*. Evidence accrues separately on the PR and is checked by the §8 merge gate, not by this script.
+All routes are asynchronous: stdout reports only that a request was *dispatched*. Evidence accrues separately on the PR and is checked by the §8 merge gate, not by this script. `route: augment (dispatched)` signals that the trigger comment was posted, not that a review has occurred.
+
+### Augment route — experimental, explicit-only
+
+`kind=augment` is experimental and must be requested explicitly. It is never added to the random reviewer pool (`{copilot, codex}`). Use it only when you know Augment Code Review is available for the target repository.
+
+**Availability guard:** the script reads `AUGMENT_REVIEW_ENABLED_OWNERS` (a comma-separated list of GitHub owner names, e.g. `t-uda`). If the env var is missing, empty, or the repo owner is not in the list, the script exits `1` with a message on stderr and does **not** call `gh`:
+
+```
+ERROR: reviewer_not_available: augment is not enabled for owner <OWNER>
+```
+
+To enable for a specific owner:
+
+```sh
+export AUGMENT_REVIEW_ENABLED_OWNERS="t-uda"
+scripts/acquire-review.py t-uda/myrepo 42 augment
+```
+
+**Dispatch vs. evidence:** posting `auggie review` is an asynchronous trigger. The §8 merge gate is responsible for determining whether actual review evidence has accrued on the PR.
 
 ### Contract
 
@@ -22,11 +42,11 @@ scripts/acquire-review.py <OWNER>/<REPO> <PR_NUMBER> [kind]
 | Exit | Meaning |
 |------|---------|
 | `0`  | The route succeeded. Stdout: `route: <kind> (dispatched)`. |
-| `1`  | Dispatch failed. Caller should record an authorized bypass per SKILL.md §7. |
+| `1`  | Dispatch failed or availability guard rejected. Caller should record an authorized bypass per SKILL.md §7. |
 | `64` | Usage error (missing arguments, too many arguments, or unknown kind). |
 | `127`| Precondition error (e.g., `gh` CLI not on `PATH`). |
 
-Pass an explicit `kind` only when the caller — or a project policy — requires a specific reviewer for this dispatch. Omit it for the reviewer-neutral default.
+Pass an explicit `kind` only when the caller — or a project policy — requires a specific reviewer for this dispatch. Omit it for the reviewer-neutral default (`{copilot, codex}`).
 
 ## Project override: `REVIEW_ACQUIRE_SCRIPT`
 

--- a/skills/github-driven-workflow/scripts/acquire-review.py
+++ b/skills/github-driven-workflow/scripts/acquire-review.py
@@ -137,6 +137,15 @@ def main(argv):
     if kind not in DISPATCHERS:
         usage(f"unknown kind: {kind!r} (allowed: {', '.join(all_kinds)})")
 
+    if kind == "augment":
+        owner = repo.split("/")[0]
+        if not check_augment_availability(owner):
+            print(
+                f"ERROR: reviewer_not_available: augment is not enabled for owner {owner}",
+                file=sys.stderr,
+            )
+            return 1
+
     if shutil.which("gh") is None:
         print("ERROR: gh not found on PATH", file=sys.stderr)
         return 127

--- a/skills/github-driven-workflow/scripts/acquire-review.py
+++ b/skills/github-driven-workflow/scripts/acquire-review.py
@@ -10,11 +10,19 @@ the env var so re-invocations do not recurse. See this skill's README.md for
 the override contract.
 
 Usage: scripts/acquire-review.py <OWNER>/<REPO> <PR_NUMBER> [kind]
-  kind: optional, one of {copilot, codex}. Omitted = uniform random pick.
+  kind: optional, one of {copilot, codex, augment}. Omitted = uniform random
+        pick from {copilot, codex}. ``augment`` is never in the random pool;
+        it must be requested explicitly.
+
+        ``augment`` requires the repo owner to be listed in the
+        ``AUGMENT_REVIEW_ENABLED_OWNERS`` environment variable (comma-separated
+        list of owner names, e.g. ``t-uda``). If the env var is missing/empty
+        or the owner is not listed, the script exits 1 before calling ``gh``.
 
 Exit codes:
   0   route succeeded (printed: "route: <kind> (dispatched)")
-  1   dispatch failed; record an authorized bypass per SKILL.md §7
+  1   dispatch failed or availability guard rejected; record an authorized
+      bypass per SKILL.md §7
   64  usage error
   127 precondition error (e.g. ``gh`` CLI missing)
 """
@@ -26,11 +34,16 @@ import subprocess
 import sys
 
 KINDS = ("copilot", "codex")
+AUGMENT_TRIGGER = "auggie review"
 
 
 def usage(msg=""):
     print(
         f"Usage: {os.path.basename(sys.argv[0])} <OWNER>/<REPO> <PR_NUMBER> [kind]",
+        file=sys.stderr,
+    )
+    print(
+        f"  kind: one of {{{', '.join((*KINDS, 'augment'))}}}; omit for random pick from {{{', '.join(KINDS)}}}",
         file=sys.stderr,
     )
     if msg:
@@ -74,7 +87,38 @@ def dispatch_codex(repo, pr):
     ).returncode == 0
 
 
-DISPATCHERS = {"copilot": dispatch_copilot, "codex": dispatch_codex}
+def check_augment_availability(owner):
+    """Return True if augment is enabled for the given owner, False otherwise.
+
+    Reads AUGMENT_REVIEW_ENABLED_OWNERS (comma-separated owner list). Returns
+    False when the env var is missing, empty, or the owner is not listed.
+    """
+    raw = os.environ.get("AUGMENT_REVIEW_ENABLED_OWNERS", "")
+    enabled_owners = {o.strip() for o in raw.split(",") if o.strip()}
+    return owner in enabled_owners
+
+
+class AugmentUnavailable(Exception):
+    """Raised when the augment availability guard rejects the request."""
+
+
+def dispatch_augment(repo, pr):
+    owner = repo.split("/")[0]
+    if not check_augment_availability(owner):
+        raise AugmentUnavailable(owner)
+    return subprocess.run(
+        [
+            "gh", "api",
+            f"repos/{repo}/issues/{pr}/comments",
+            "-X", "POST",
+            "-f", f"body={AUGMENT_TRIGGER}",
+        ],
+        capture_output=True,
+        text=True,
+    ).returncode == 0
+
+
+DISPATCHERS = {"copilot": dispatch_copilot, "codex": dispatch_codex, "augment": dispatch_augment}
 
 
 def main(argv):
@@ -89,14 +133,25 @@ def main(argv):
     repo, pr = argv[1], argv[2]
     kind = argv[3] if len(argv) == 4 else random.choice(KINDS)
 
+    all_kinds = (*KINDS, "augment")
     if kind not in DISPATCHERS:
-        usage(f"unknown kind: {kind!r} (allowed: {', '.join(KINDS)})")
+        usage(f"unknown kind: {kind!r} (allowed: {', '.join(all_kinds)})")
 
     if shutil.which("gh") is None:
         print("ERROR: gh not found on PATH", file=sys.stderr)
         return 127
 
-    if DISPATCHERS[kind](repo, pr):
+    try:
+        dispatched = DISPATCHERS[kind](repo, pr)
+    except AugmentUnavailable as exc:
+        owner = str(exc)
+        print(
+            f"ERROR: reviewer_not_available: augment is not enabled for owner {owner}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if dispatched:
         print(f"route: {kind} (dispatched)")
         return 0
 

--- a/skills/github-driven-workflow/scripts/test_acquire_review.sh
+++ b/skills/github-driven-workflow/scripts/test_acquire_review.sh
@@ -172,6 +172,42 @@ write_fake_gh 0 0
 out="$(PATH="${BIN}" REVIEW_ACQUIRE_SCRIPT="${ACQUIRE}" "$ACQUIRE" owner/repo 1 copilot 2>&1)"
 check '[[ "$out" == "route: copilot (dispatched)" ]]' "REVIEW_ACQUIRE_SCRIPT pointing at self ⇒ falls through to built-in"
 
+# --- kind=augment with enabled owner → posts trigger comment, exits 0 ---
+write_fake_gh 0 0
+set +e
+out="$(PATH="${BIN}" AUGMENT_REVIEW_ENABLED_OWNERS="t-uda" run_acquire t-uda/myrepo 42 augment)"
+rc=$?
+set -e
+check '[[ "$rc" == "0" ]]' "kind=augment with enabled owner ⇒ exit 0"
+check '[[ "$out" == "route: augment (dispatched)" ]]' "kind=augment with enabled owner ⇒ route: augment (dispatched)"
+check 'grep -q "argv:.*issues/42/comments" "${GH_LOG}"' "kind=augment with enabled owner ⇒ issues comments API hit"
+
+# --- kind=augment with disabled owner → exits 1, does NOT call gh ---
+: >"${GH_LOG}"
+set +e
+out="$(PATH="${BIN}" AUGMENT_REVIEW_ENABLED_OWNERS="other-owner" run_acquire t-uda/myrepo 42 augment 2>&1)"
+rc=$?
+set -e
+check '[[ "$rc" == "1" ]]' "kind=augment with disabled owner ⇒ exit 1"
+check '[[ "$out" == *"reviewer_not_available: augment is not enabled for owner t-uda"* ]]' "kind=augment with disabled owner ⇒ error message on stderr"
+check '! grep -q "argv:" "${GH_LOG}"' "kind=augment with disabled owner ⇒ gh not called"
+
+# --- kind omitted → augment is NOT selected (random pool is {copilot, codex} only) ---
+write_fake_gh 0 0
+seen_augment=0
+for _ in $(seq 1 50); do
+  out="$(AUGMENT_REVIEW_ENABLED_OWNERS="t-uda" run_acquire t-uda/myrepo 1)"
+  case "$out" in
+    "route: augment (dispatched)") seen_augment=1 ;;
+  esac
+done
+check '[[ "$seen_augment" -eq 0 ]]' "kind omitted ⇒ augment never selected in 50 runs (not in random pool)"
+
+# --- dispatch success → prints route: augment (dispatched) ---
+write_fake_gh 0 0
+out="$(PATH="${BIN}" AUGMENT_REVIEW_ENABLED_OWNERS="t-uda" run_acquire t-uda/myrepo 7 augment)"
+check '[[ "$out" == "route: augment (dispatched)" ]]' "augment dispatch success ⇒ prints route: augment (dispatched)"
+
 echo
 echo "Result: ${pass} passed, ${fail} failed"
 [[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## Summary

- Adds `kind=augment` to `scripts/acquire-review.py`: posts `auggie review` as a manual trigger comment for Augment Code Review.
- Guards the route with `AUGMENT_REVIEW_ENABLED_OWNERS` env var (comma-separated owner list); exits 1 without calling `gh` if the repo owner is not listed.
- `augment` is explicit-only and excluded from the random reviewer pool (`{copilot, codex}`).
- Updates `README.md` with the new route, availability guard docs, dispatch-vs-evidence distinction, and experimental status.
- Adds 4 new smoke tests covering: enabled owner, disabled owner (gh not called), random-pool exclusion, and dispatch output.

Closes #110.

## Validation

```
bash skills/github-driven-workflow/scripts/test_acquire_review.sh
```

```
Result: 23 passed, 0 failed
```

All 23 tests pass (15 pre-existing + 4 new augment cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)