### PR TITLE
computational-reproducibility: cover intra-computation (degenerate-intermediate) fallbacks

### DIFF
--- a/skills/computational-reproducibility/SKILL.md
+++ b/skills/computational-reproducibility/SKILL.md
@@ -9,6 +9,10 @@ Use this skill to keep computational experiments reproducible before expensive e
 
 The goal is experimental discipline: fail early on invalid setup, keep source and generated artifacts separate, record enough identity to rerun work, and report scientific outcomes without ambiguous status labels.
 
+## Scientific stance
+
+Treat each computation as a scientific claim, not merely working code. Imagine writing the method up as equations: if a faithful write-up would have to carry a thicket of ad-hoc case splits, divide-by-zero guards, domain clipping, tuned regularization constants, or fallbacks, the result has drifted from **science** toward engineering expedience. Such devices may be sound engineering, but they belong in a scientific account only when they are part of the *declared* method — chosen deliberately, recorded, and visible in the write-up — never inserted silently to make a degenerate case disappear. When in doubt, hard-fail and surface the degeneracy rather than quietly patch past it.
+
 ## When to use
 
 Use this skill when:
@@ -49,8 +53,12 @@ The same rule governs fallbacks **inside** a computation, not only at its inputs
 - zero or near-zero weight sum substituted with uniform (or any) weights
 - empty collection reduced to a default constant
 - zero or near-zero denominator, norm, or scale substituted with a constant
+- divide-by-zero dodged by adding a small constant to a denominator (e.g. `x / (denom + 1e-8)`) instead of confronting the degeneracy
+- an out-of-domain intermediate clipped into the valid range to suppress an error (e.g. clamping before `log`/`sqrt`/`arccos`, or clipping probabilities into `(0, 1)`)
 - undefined primary estimator silently swapped for an alternate estimator or method
 - NaN or missing value filled with 0 (or any constant)
+
+This forbids silent divide-by-zero avoidance and domain clipping specifically: they may never be applied without the explicit opt-in above. Declared, recorded regularization or clipping that *is* the method (e.g. ridge regression, gradient clipping) is fine; the prohibition targets ad-hoc guards inserted to make a degenerate intermediate disappear.
 
 Judge such a fallback by **impact if triggered**, not only by whether it fires on current data. A guard that never fires now can still be scientifically catastrophic if it would — for example a substituted scale that silently yields an order-of-magnitude-wrong result without signalling an error. A fallback that fires on a non-trivial fraction of inputs is itself a signal that the **primary** path's definition may be wrong; investigate the spec before accepting the fallback.
 
@@ -176,7 +184,7 @@ Before submitting changes involving computational experiments or generated outpu
 - Artifact layout has stable source/output separation and run identity.
 - Failure states distinguish `not-run`, `skipped`, `failed`, `empty-result`, and `zero-result`.
 - Any fallback is explicit, opted in, and visible in outputs or manifest.
-- No silent substitution for degenerate intermediates or estimators. Preflight and manifest checks do not surface runtime numerical guards, so read the code: grep for `or <const>`, `if x <= 0: x = <const>`, a default or initial value supplied to a reduce/fold/max/min, `nan_to_num` and equivalents, NaN-skipping reducers such as `nanmean`/`nanmax`/`nansum` (silent drop), and try/except or try/catch blocks returning a default.
+- No silent substitution, divide-by-zero guard, domain clipping, or regularization for degenerate intermediates or estimators. Preflight and manifest checks do not surface runtime numerical guards, so read the code: grep for `or <const>`, `if x <= 0: x = <const>`, a small constant added to a denominator (`+ <eps>`, `+ 1e-`), `clip`/`clamp` into a valid domain, a default or initial value supplied to a reduce/fold/max/min, `nan_to_num` and equivalents, NaN-skipping reducers such as `nanmean`/`nanmax`/`nansum` (silent drop), and try/catch blocks returning a default.
 - Each fallback is judged by impact if triggered, not only by whether it fires now; a high trigger rate is treated as a flag that the primary path may be misdefined.
 - Host-specific paths, credentials, and local cache assumptions are not required for reproducibility.
 

--- a/skills/computational-reproducibility/SKILL.md
+++ b/skills/computational-reproducibility/SKILL.md
@@ -44,7 +44,7 @@ Fallbacks are allowed only when all of these are true:
 
 Do not silently substitute sample data, cached outputs, smaller models, different backends, local paths, or alternate datasets.
 
-The same rule governs fallbacks **inside** a computation, not only at its inputs. Silently replacing a degenerate intermediate or estimator with a default is forbidden under the identical conditions (hard-fail, or explicit opt-in + recorded + visible in outputs + distinguishable in review). Examples across domains:
+The same rule governs fallbacks **inside** a computation, not only at its inputs. Silently replacing a degenerate intermediate or estimator with a default must hard-fail too, and is allowed only when the same four conditions hold (explicit opt-in + recorded + visible in outputs + distinguishable in review). Examples across domains:
 
 - zero or near-zero weight sum substituted with uniform (or any) weights
 - empty collection reduced to a default constant
@@ -52,7 +52,7 @@ The same rule governs fallbacks **inside** a computation, not only at its inputs
 - undefined primary estimator silently swapped for an alternate estimator or method
 - NaN or missing value filled with 0 (or any constant)
 
-Judge such a fallback by **impact if triggered**, not only by whether it fires on current data. A guard that never fires now can still be scientifically catastrophic if it would — for example a substituted scale that silently yields an order-of-magnitude-wrong result with no raise. A fallback that fires on a non-trivial fraction of inputs is itself a signal that the **primary** path's definition may be wrong; investigate the spec before accepting the fallback.
+Judge such a fallback by **impact if triggered**, not only by whether it fires on current data. A guard that never fires now can still be scientifically catastrophic if it would — for example a substituted scale that silently yields an order-of-magnitude-wrong result without signalling an error. A fallback that fires on a non-trivial fraction of inputs is itself a signal that the **primary** path's definition may be wrong; investigate the spec before accepting the fallback.
 
 ### Separate source and artifacts
 
@@ -176,7 +176,7 @@ Before submitting changes involving computational experiments or generated outpu
 - Artifact layout has stable source/output separation and run identity.
 - Failure states distinguish `not-run`, `skipped`, `failed`, `empty-result`, and `zero-result`.
 - Any fallback is explicit, opted in, and visible in outputs or manifest.
-- No silent substitution for degenerate intermediates or estimators. Preflight and manifest checks do not surface runtime numerical guards, so read the code: grep for `or <const>`, `if x <= 0: x = <const>`, `default=` in max/min/reduce, `nan_to_num`, and `nanmean`/`nanmax`/`nansum` (silent drop), and try/except blocks returning a default.
+- No silent substitution for degenerate intermediates or estimators. Preflight and manifest checks do not surface runtime numerical guards, so read the code: grep for `or <const>`, `if x <= 0: x = <const>`, a default or initial value supplied to a reduce/fold/max/min, `nan_to_num` and equivalents, NaN-skipping reducers such as `nanmean`/`nanmax`/`nansum` (silent drop), and try/except or try/catch blocks returning a default.
 - Each fallback is judged by impact if triggered, not only by whether it fires now; a high trigger rate is treated as a flag that the primary path may be misdefined.
 - Host-specific paths, credentials, and local cache assumptions are not required for reproducibility.
 

--- a/skills/computational-reproducibility/SKILL.md
+++ b/skills/computational-reproducibility/SKILL.md
@@ -44,6 +44,16 @@ Fallbacks are allowed only when all of these are true:
 
 Do not silently substitute sample data, cached outputs, smaller models, different backends, local paths, or alternate datasets.
 
+The same rule governs fallbacks **inside** a computation, not only at its inputs. Silently replacing a degenerate intermediate or estimator with a default is forbidden under the identical conditions (hard-fail, or explicit opt-in + recorded + visible in outputs + distinguishable in review). Examples across domains:
+
+- zero or near-zero weight sum substituted with uniform (or any) weights
+- empty collection reduced to a default constant
+- zero or near-zero denominator, norm, or scale substituted with a constant
+- undefined primary estimator silently swapped for an alternate estimator or method
+- NaN or missing value filled with 0 (or any constant)
+
+Judge such a fallback by **impact if triggered**, not only by whether it fires on current data. A guard that never fires now can still be scientifically catastrophic if it would — for example a substituted scale that silently yields an order-of-magnitude-wrong result with no raise. A fallback that fires on a non-trivial fraction of inputs is itself a signal that the **primary** path's definition may be wrong; investigate the spec before accepting the fallback.
+
 ### Separate source and artifacts
 
 Keep source files and generated artifacts distinct.
@@ -152,7 +162,7 @@ When running an experiment:
 6. Record the final status using the failure semantics above.
 7. Keep generated artifacts out of source control unless explicitly authorized.
 
-When modifying an existing workflow, preserve stricter behaviour. Do not add silent fallback, implicit path discovery, or source/artifact conflation for convenience.
+When modifying an existing workflow, preserve stricter behaviour. Do not add silent fallback, implicit path discovery, runtime substitution for degenerate intermediates, or source/artifact conflation for convenience.
 
 ## Review checklist
 
@@ -166,6 +176,8 @@ Before submitting changes involving computational experiments or generated outpu
 - Artifact layout has stable source/output separation and run identity.
 - Failure states distinguish `not-run`, `skipped`, `failed`, `empty-result`, and `zero-result`.
 - Any fallback is explicit, opted in, and visible in outputs or manifest.
+- No silent substitution for degenerate intermediates or estimators. Preflight and manifest checks do not surface runtime numerical guards, so read the code: grep for `or <const>`, `if x <= 0: x = <const>`, `default=` in max/min/reduce, `nan_to_num`, and `nanmean`/`nanmax`/`nansum` (silent drop), and try/except blocks returning a default.
+- Each fallback is judged by impact if triggered, not only by whether it fires now; a high trigger rate is treated as a flag that the primary path may be misdefined.
 - Host-specific paths, credentials, and local cache assumptions are not required for reproducibility.
 
 ## Stop conditions

--- a/skills/computational-reproducibility/SKILL.md
+++ b/skills/computational-reproducibility/SKILL.md
@@ -11,7 +11,7 @@ The goal is experimental discipline: fail early on invalid setup, keep source an
 
 ## Scientific stance
 
-Treat each computation as a scientific claim, not merely working code. Imagine writing the method up as equations: if a faithful write-up would have to carry a thicket of ad-hoc case splits, divide-by-zero guards, domain clipping, tuned regularization constants, or fallbacks, the result has drifted from **science** toward engineering expedience. Such devices may be sound engineering, but they belong in a scientific account only when they are part of the *declared* method — chosen deliberately, recorded, and visible in the write-up — never inserted silently to make a degenerate case disappear. When in doubt, hard-fail and surface the degeneracy rather than quietly patch past it.
+Treat each computation as a scientific claim, not merely working code. If reproducing the result faithfully would require equations laced with ad-hoc case splits, divide-by-zero guards, domain clipping, tuned regularization constants, or fallbacks, it has drifted from **science** toward engineering expedience: such devices belong in a scientific account only as part of the *declared* method — chosen deliberately, recorded, and visible — never inserted silently to make a degenerate case disappear. When in doubt, hard-fail and surface the degeneracy rather than patch past it.
 
 ## When to use
 
@@ -48,7 +48,7 @@ Fallbacks are allowed only when all of these are true:
 
 Do not silently substitute sample data, cached outputs, smaller models, different backends, local paths, or alternate datasets.
 
-The same rule governs fallbacks **inside** a computation, not only at its inputs. Silently replacing a degenerate intermediate or estimator with a default must hard-fail too, and is allowed only when the same four conditions hold (explicit opt-in + recorded + visible in outputs + distinguishable in review). Examples across domains:
+The same rule governs fallbacks **inside** a computation, not only at its inputs. Replacing a degenerate intermediate or estimator with a default hard-fails by default; take the fallback path only when the same four conditions hold (explicit opt-in + recorded + visible in outputs + distinguishable in review). Examples across domains:
 
 - zero or near-zero weight sum substituted with uniform (or any) weights
 - empty collection reduced to a default constant
@@ -184,7 +184,7 @@ Before submitting changes involving computational experiments or generated outpu
 - Artifact layout has stable source/output separation and run identity.
 - Failure states distinguish `not-run`, `skipped`, `failed`, `empty-result`, and `zero-result`.
 - Any fallback is explicit, opted in, and visible in outputs or manifest.
-- No silent substitution, divide-by-zero guard, domain clipping, or regularization for degenerate intermediates or estimators. Preflight and manifest checks do not surface runtime numerical guards, so read the code: grep for `or <const>`, `if x <= 0: x = <const>`, a small constant added to a denominator (`+ <eps>`, `+ 1e-`), `clip`/`clamp` into a valid domain, a default or initial value supplied to a reduce/fold/max/min, `nan_to_num` and equivalents, NaN-skipping reducers such as `nanmean`/`nanmax`/`nansum` (silent drop), and try/catch blocks returning a default.
+- No silent, undeclared substitution, divide-by-zero guard, domain clipping, or regularization patching a degenerate intermediate or estimator (declared methods recorded per the rule above are fine). Preflight and manifest checks do not surface runtime numerical guards, so read the code, grepping for patterns such as: a literal `or` followed by a constant, `if x <= 0: x = ...`, a small constant added to a denominator (`+ 1e-8`, `+ eps`), `clip`/`clamp` into a valid domain, a default or initial value supplied to a reduce/fold/max/min, `nan_to_num` and equivalents, NaN-skipping reducers such as `nanmean`/`nanmax`/`nansum` (silent drop), and try/catch blocks returning a default.
 - Each fallback is judged by impact if triggered, not only by whether it fires now; a high trigger rate is treated as a flag that the primary path may be misdefined.
 - Host-specific paths, credentials, and local cache assumptions are not required for reproducibility.
 


### PR DESCRIPTION
Closes #115

## What & why (changelog)

- Extend `No implicit fallback` past the input/environment layer to **intra-computation** fallbacks: silent substitution of a default for a degenerate intermediate/estimator (zero/near-zero weight sum, empty reduction, near-zero denominator/norm/scale, undefined estimator, NaN/missing fill), governed by the identical hard-fail-or-opt-in+recorded+visible+distinguishable rule. These produce valid-looking results with unrecorded provenance — the exact harm the skill exists to prevent.
- Add a **severity lens** (judge by impact-if-triggered, not only whether it fires now) and a **trigger-rate heuristic** (a high firing rate flags a misdefined primary path; investigate the spec first).
- Add a **code-level grep probe** to the review checklist, because preflight/manifest checks do not surface runtime numerical guards (`or <const>`, `if x <= 0: x = <const>`, `default=` in reduce, `nan_to_num`, `nan*` silent drop, try/except returning a default).
- Domain-neutral wording validated against simulation, ML training, numerical linear algebra, and signal/image processing. Failure-semantics and manifest guidance left unchanged.

## Validation

- `git diff --stat`: +13/-1 in one file (no long appended section).
- Confirmed Failure-semantics and manifest sections are unchanged (grep over diff returned no hits within those lines).
- No repo CI/lint tooling (`package.json`, `.textlintrc`, `.github/workflows` all absent), so no automated checks to run; markdown reviewed manually.