### PR TITLE
Add three math-writing review skills (claim integrity, notation consistency, wabun style)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository stores reusable agent skills and a small amount of supporting do
 
 ## Rules
 
-- Keep all repository text and skill artifacts in English.
+- Keep all repository text and skill artifacts in English. Exception: a skill whose subject is non-English text (e.g. a language-review skill) may contain that language as quoted linguistic data — examples, terms under review, and replacement phrases; rule prose and structure remain in English.
 - Store each skill at `skills/<skill-name>/SKILL.md`.
 - Keep each skill narrow, explicit, and operational.
 - Avoid registry-specific assumptions in skill content.

--- a/skills/README.md
+++ b/skills/README.md
@@ -36,3 +36,6 @@ Current skills:
 - claude-code-advanced-orchestration
 - textlint-cli
 - github-project-board-maintenance
+- math-claim-integrity
+- math-notation-consistency
+- wabun-math-style

--- a/skills/math-claim-integrity/SKILL.md
+++ b/skills/math-claim-integrity/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: math-claim-integrity
+description: Audit the structural and logical integrity of a mathematics paper — quantifier scope, domain-of-definition guards, proof/computation honesty, theorem hierarchy, stale claims, notation accuracy at introduction, standing assumptions, and undefined relation symbols or coined terms in summary prose — without touching prose style or inflation patterns.
+---
+
+# Math Claim Integrity
+
+Audit a mathematics paper for structural and logical integrity defects: quantifier scope errors, missing domain-of-definition guards, conflation of analytic proofs with numerical evidence, theorem-hierarchy misclassification, stale open-problem claims, notation mislabeling at introduction, define-before-use violations, and standing-assumption drift. This skill does not touch prose style, inflation, or hype (use `deslop-prose`), and does not track symbol drift across sections (use `math-notation-consistency`).
+
+## Use when
+
+Use this skill when:
+- A math paper draft needs pre-submission structural review
+- A theorem was reorganized and surrounding text may not reflect the new hierarchy
+- A quantifier scope error (for-all vs exists, iff vs implies, general vs special-case) is suspected
+- The introduction or abstract may over-claim or misstate what the theorems actually prove
+- A proof section may be conflating analytic argument with numerical/computational evidence
+- An open problem claim may have been resolved by a theorem proved later in the same document
+- A symbol or concept may be named in a way that misrepresents its mathematical role
+- The abstract, introduction, or conclusion uses a relation symbol (≺, ⊏, an ad hoc ordering) or a coined comparative term (階層, 検出力, "strictly finer") that is never formally defined in the body
+
+## Do not use
+
+Do not use this skill for:
+- Prose inflation, hype, or AI-generated decoration → use `deslop-prose`
+- Symbol-table drift across sections → use `math-notation-consistency`
+- Japanese-specific language anti-patterns → use `wabun-math-style`
+- Discussion-history artifacts in planning docs → use `deslop-history`
+
+## Inputs
+
+Gather or infer these before starting:
+- `artifact` — the LaTeX file or section range to audit
+- `main_theorem` — the result the paper is organized around (if known)
+- `citation_boundary` — what is credited to cited works vs. new in this paper
+- `proof_mode` — analytic/algebraic, numerical/computational, or mixed
+
+## Procedure
+
+1. Read the abstract and introduction. List all informal theorem descriptions.
+2. Locate every theorem-level environment (theorem, proposition, lemma, corollary) in the body.
+3. Apply rules R-A through R-L in sequence; record findings.
+4. Produce a structured finding report.
+
+## Rules
+
+**R-A — Quantifier exactness.**
+Every claim must be stated at exactly the quantifier strength the proof establishes. Flag: "iff" when only one implication is proved; "for all t" when the proof only establishes "for sufficiently small t" or "for fixed t"; "for any configuration" when the result depends on a specific configuration; a general formula when only a special case was derived. The quantifier structure of the statement must match the quantifier structure of the proof.
+
+**R-B — Domain-of-definition guard.**
+Any quantity defined via a potentially-failing operation (matrix inverse, division, limit, logarithm) must: (a) name its failure locus at the point of definition, and (b) have every subsequent universal claim over that quantity guarded by the same condition. Example: magnitude defined via Z_X(t)^{-1} must state that it is defined only where Z_X(t) is invertible; every "for all t" claim about magnitude must be guarded by "for all t where Z_X(t) is invertible" or equivalent.
+
+**R-C — Attribution boundary.**
+Each theorem/proposition must be unambiguously classifiable as: (i) cited verbatim, (ii) restated/repackaged from a citation, or (iii) original to this paper. Infrastructure from cited works (realization constructions, prior existence results) must not be presented as the paper's own novel contribution. Conversely, genuinely original results must carry an explicit claim of novelty or must not be attributed to prior work by passive or vague phrasing. For the voice mechanics of attribution in Japanese (passive 〜が示されている vs active 〜を示す), cross-reference `wabun-math-style` rule JP-3. When the `citation_boundary` input is not supplied, all R-C findings are automatically severity NOTE ("unverifiable attribution") rather than BLOCKING or MINOR — flag the location but do not assert novelty or citedness without the boundary information.
+
+**R-D — Proof/computation honesty.**
+Analytic/algebraic proofs and numerical/computational verifications must be strictly separated. Rules: every decimal value must be labeled as approximate or as a convenience form of an exact quantity; a load-bearing numerical claim must either have a closed-form analytic companion OR an explicit statement that the result is a certified numerical result (interval arithmetic, exact-arithmetic computation, rigorous exhaustive finite case enumeration with exact decision) with a statement of why a closed form is unavailable; grid-search or script output may be labeled as motivation or corroboration but not as a proof step.
+
+**R-E — Stale-claim elimination.**
+Scan for claims labeled open, unresolved, conjectural, or under investigation. For each, check whether the paper itself contains a theorem that resolves the claim. A claim labeled "open" that is resolved by a theorem proved elsewhere in the same document is a hard error. A condition listed as an assumption in a theorem that the paper later proves is universally satisfied should be flagged for the author to confirm removal (MINOR severity), as authors sometimes intentionally retain explicit hypotheses for modularity or citability.
+
+**R-F — Theorem hierarchy.**
+If a result is proved solely as input to another theorem, it should be labeled Lemma or Proposition, not Theorem, and should not be enumerated independently in the §1 contribution list. If the introduction lists "three main results" and one of them is only used in the proof of another, flag the hierarchy. Conversely, the paper's central result — the one the title and abstract advertise — must appear as a named Theorem in the body, not only as a corollary of a more general statement introduced without emphasis.
+
+**R-G — Introduction–body consistency.**
+Every informal theorem description in §1 (introduction, contributions list) must match the actual formal statement in the body. Check: quantifier direction, domain of validity, what is assumed vs. what is concluded, and what is credited to prior work vs. original. Discrepancies are most often in the introduction; fix there. Note: §1 descriptions may be informal paraphrases but must not be strictly stronger or weaker than the formal statement.
+
+**R-H — Worked example placement (advisory).**
+When the paper's proof strategy is "construct an explicit family, then abstract to a general theorem," the worked example should appear before the general theorem so readers can verify the mechanism concretely. Flag only if a worked example is referenced in the proof before it is introduced, or if the general theorem is cited in the example section in a circular way. This is an advisory finding, not a blocking error.
+
+**R-I — Notation conceptual accuracy at introduction.**
+When a symbol is introduced, its name, LaTeX macro, and description must match its mathematical role. A symbol described as "an invariant" that in fact depends on a varying parameter is a mislabeling. A macro `\Mag` used for an operator that is not the standard magnitude operator is confusing. Flag at the point of introduction, not later uses. Later-use consistency across sections is out of scope for this skill.
+
+**R-J — Define before use.**
+Every symbol appearing in a theorem statement, proof step, or displayed formula must have a formal definition or explicit introduction earlier in the document (not in a later remark or footnote). Check that every LaTeX macro used in theorem environments is either a standard math symbol or explicitly defined in the preamble or body before its first theorem-context use. Cross-section symbol bookkeeping (single definition site, back-references after gaps) is handled by `math-notation-consistency` once available. R-J owns completeness of theorem statements; `math-notation-consistency` owns cross-section consistency.
+
+**R-K — Standing assumption inheritance.**
+When a section or theorem relies on standing assumptions declared earlier (e.g., "throughout this section, X is a finite metric space with property P"), every theorem in that section must either inherit those assumptions explicitly or state explicitly that it holds without them. After a structural revision (reordering sections, splitting a theorem), check that standing assumptions have not been silently dropped or silently over-applied. Flag any theorem whose hypothesis list differs from the standing assumptions without explanation.
+
+**R-L — No undefined relation symbols or coined terms in claims.**
+Every relation symbol (≺, ⊏, ⋖, an arrow used as an ordering, or any ad hoc comparative notation) and every coined comparative term ("階層", "検出力の順", "strictly finer/coarser than") that appears in the abstract, introduction, or conclusion must either (a) have a formal definition in the body before (or explicitly referenced at) the point of use, or (b) be replaced by the explicit logical statement it abbreviates. The standard unpacking of "invariant I₁ is strictly coarser than I₂" is: every pair distinguished by I₁ is distinguished by I₂, and there exists a pair on which I₁ agrees while I₂ differs — state both halves with references to the theorems that prove them. An undefined ≺ in a summary section is BLOCKING even when the intended meaning is guessable, because the reader cannot verify the claim against a definition. Division of labour: `math-notation-consistency` NC-1 owns the bookkeeping of definition sites; R-L owns the requirement that abstract/intro/conclusion claims be expressible entirely in defined terms.
+
+## Examples
+
+```
+Before: S_r は等長不変量である．
+After:  S_r は配置 E を入力とする Fourier 座標であり，配置によって変化する（等長不変量ではない）．
+```
+
+```
+Before: Magnitude は各 t > 0 で定義される．
+After:  Magnitude は Z_X(t) が正則となる t において定義される．
+```
+
+```
+Before: [In §1 contributions list] Theorem A, Theorem B, Theorem C are proved.
+        [In body] Theorem C is used only in the proof of Theorem B.
+After:  [In §1] Theorem B (main result) is proved, using Proposition C as infrastructure.
+```
+
+```
+Before: グリッドサーチにより，α β − 3(γ−δ)² < 0 が確認された。
+After:  [NUMERICAL/coarse-grid] グリッドサーチにより α β − 3(γ−δ)² < 0 を観察した。
+        厳密な証明は §3 の解析的議論による。
+```
+
+```
+Before: The general case remains open.
+        [Later in the same paper] Theorem 4.1 (General case): ...
+After:  [Remove the "remains open" claim; update all cross-references to point to Theorem 4.1.]
+```
+
+```
+Before: ゼータ行列から読める不変量は magnitude ≺ ν₋ ≺ σ ≺ 等長型 と階層化される。
+        （≺ は本文のどこでも定義されていない）
+After:  magnitude，ν₋ プロファイル，σ，等長型は，この順に配置を真に細かく区別する．
+        すなわち，隣接する各対について，前者が一致し後者が異なる配置対が存在する（定理 6.5）．
+```
+
+## Output
+
+Default: review-only. Produce a structured finding report listing:
+- Rule tag (R-A through R-L)
+- Severity: BLOCKING (logical/structural error) / MINOR (advisory) / NOTE (suggestion)
+- Location: section heading, theorem label, or equation reference
+- One-sentence description of the violation
+- A concrete rewrite suggestion
+
+When the user explicitly asks to apply fixes: edit the LaTeX source in-place and append a change log with rule tag, location, and before/after text. Do not change notation macros or theorem numbering without explicit instruction.
+
+## Quality Check
+
+Before finishing, verify:
+- Every finding has a rule tag, severity, and location
+- No finding overlaps with deslop-prose territory (prose inflation/hype)
+- No finding reports a symbol-table issue that belongs to math-notation-consistency
+- Advisory findings (R-H) are clearly marked MINOR, not BLOCKING
+
+## Relationship to Other Skills
+
+- Use `deslop-prose` when the problem is inflated prose, hype, or AI-generated decoration.
+- Use `wabun-math-style` for Japanese-language anti-patterns (epistemic hedges, verb tense, particle misuse).
+- Use `math-notation-consistency` for symbol drift across sections, orphaned macros, or alias detection.
+- Use `deslop-history` when a planning or notes artifact leaks process history or prior-draft residue.

--- a/skills/math-claim-integrity/SKILL.md
+++ b/skills/math-claim-integrity/SKILL.md
@@ -5,7 +5,7 @@ description: Audit the structural and logical integrity of a mathematics paper �
 
 # Math Claim Integrity
 
-Audit a mathematics paper for structural and logical integrity defects: quantifier scope errors, missing domain-of-definition guards, conflation of analytic proofs with numerical evidence, theorem-hierarchy misclassification, stale open-problem claims, notation mislabeling at introduction, define-before-use violations, and standing-assumption drift. This skill does not touch prose style, inflation, or hype (use `deslop-prose`), and does not track symbol drift across sections (use `math-notation-consistency`).
+Audit a mathematics paper for structural and logical integrity defects: quantifier scope errors, missing domain-of-definition guards, conflation of analytic proofs with numerical evidence, theorem-hierarchy misclassification, stale open-problem claims, notation mislabeling at introduction, define-before-use violations, and standing-assumption drift. The skill is language-agnostic and field-agnostic: the rules apply to any area of mathematics and to papers written in any language. It does not touch prose style, inflation, or hype (use `deslop-prose`), and does not track symbol drift across sections (use `math-notation-consistency`).
 
 ## Use when
 
@@ -17,7 +17,7 @@ Use this skill when:
 - A proof section may be conflating analytic argument with numerical/computational evidence
 - An open problem claim may have been resolved by a theorem proved later in the same document
 - A symbol or concept may be named in a way that misrepresents its mathematical role
-- The abstract, introduction, or conclusion uses a relation symbol (≺, ⊏, an ad hoc ordering) or a coined comparative term (階層, 検出力, "strictly finer") that is never formally defined in the body
+- The abstract, introduction, or conclusion uses a relation symbol (≺, ⊏, an ad hoc ordering) or a coined comparative term ("strictly finer than", "detection hierarchy", or an equivalent coinage in any language) that is never formally defined in the body
 
 ## Do not use
 
@@ -45,13 +45,13 @@ Gather or infer these before starting:
 ## Rules
 
 **R-A — Quantifier exactness.**
-Every claim must be stated at exactly the quantifier strength the proof establishes. Flag: "iff" when only one implication is proved; "for all t" when the proof only establishes "for sufficiently small t" or "for fixed t"; "for any configuration" when the result depends on a specific configuration; a general formula when only a special case was derived. The quantifier structure of the statement must match the quantifier structure of the proof.
+Every claim must be stated at exactly the quantifier strength the proof establishes. Flag: "iff" when only one implication is proved; "for all t" when the proof only establishes "for sufficiently small t" or "for fixed t"; "for any input" when the result depends on a specific instance; a general formula when only a special case was derived. The quantifier structure of the statement must match the quantifier structure of the proof.
 
 **R-B — Domain-of-definition guard.**
-Any quantity defined via a potentially-failing operation (matrix inverse, division, limit, logarithm) must: (a) name its failure locus at the point of definition, and (b) have every subsequent universal claim over that quantity guarded by the same condition. Example: magnitude defined via Z_X(t)^{-1} must state that it is defined only where Z_X(t) is invertible; every "for all t" claim about magnitude must be guarded by "for all t where Z_X(t) is invertible" or equivalent.
+Any quantity defined via a potentially-failing operation (matrix inverse, division, limit, logarithm) must: (a) name its failure locus at the point of definition, and (b) have every subsequent universal claim over that quantity guarded by the same condition. Example: a quantity defined via the inverse of a parameter-dependent matrix A(t) must state that it is defined only where A(t) is invertible; every "for all t" claim about it must be guarded by "for all t where A(t) is invertible" or equivalent.
 
 **R-C — Attribution boundary.**
-Each theorem/proposition must be unambiguously classifiable as: (i) cited verbatim, (ii) restated/repackaged from a citation, or (iii) original to this paper. Infrastructure from cited works (realization constructions, prior existence results) must not be presented as the paper's own novel contribution. Conversely, genuinely original results must carry an explicit claim of novelty or must not be attributed to prior work by passive or vague phrasing. For the voice mechanics of attribution in Japanese (passive 〜が示されている vs active 〜を示す), cross-reference `wabun-math-style` rule JP-3. When the `citation_boundary` input is not supplied, all R-C findings are automatically severity NOTE ("unverifiable attribution") rather than BLOCKING or MINOR — flag the location but do not assert novelty or citedness without the boundary information.
+Each theorem/proposition must be unambiguously classifiable as: (i) cited verbatim, (ii) restated/repackaged from a citation, or (iii) original to this paper. Infrastructure from cited works (constructions, prior existence results) must not be presented as the paper's own novel contribution. Conversely, genuinely original results must carry an explicit claim of novelty or must not be attributed to prior work by passive or vague phrasing. For the voice mechanics of attribution in Japanese (passive 〜が示されている vs active 〜を示す), cross-reference `wabun-math-style` rule JP-3. When the `citation_boundary` input is not supplied, all R-C findings are automatically severity NOTE ("unverifiable attribution") rather than BLOCKING or MINOR — flag the location but do not assert novelty or citedness without the boundary information.
 
 **R-D — Proof/computation honesty.**
 Analytic/algebraic proofs and numerical/computational verifications must be strictly separated. Rules: every decimal value must be labeled as approximate or as a convenience form of an exact quantity; a load-bearing numerical claim must either have a closed-form analytic companion OR an explicit statement that the result is a certified numerical result (interval arithmetic, exact-arithmetic computation, rigorous exhaustive finite case enumeration with exact decision) with a statement of why a closed form is unavailable; grid-search or script output may be labeled as motivation or corroboration but not as a proof step.
@@ -69,52 +69,56 @@ Every informal theorem description in §1 (introduction, contributions list) mus
 When the paper's proof strategy is "construct an explicit family, then abstract to a general theorem," the worked example should appear before the general theorem so readers can verify the mechanism concretely. Flag only if a worked example is referenced in the proof before it is introduced, or if the general theorem is cited in the example section in a circular way. This is an advisory finding, not a blocking error.
 
 **R-I — Notation conceptual accuracy at introduction.**
-When a symbol is introduced, its name, LaTeX macro, and description must match its mathematical role. A symbol described as "an invariant" that in fact depends on a varying parameter is a mislabeling. A macro `\Mag` used for an operator that is not the standard magnitude operator is confusing. Flag at the point of introduction, not later uses. Later-use consistency across sections is out of scope for this skill.
+When a symbol is introduced, its name, LaTeX macro, and description must match its mathematical role. A symbol described as "an invariant" that in fact depends on a varying parameter or an auxiliary choice (a basis, an ordering, an embedding) is a mislabeling. A macro whose name suggests a standard operator but denotes a nonstandard variant is confusing. Flag at the point of introduction, not later uses. Later-use consistency across sections is out of scope for this skill.
 
 **R-J — Define before use.**
-Every symbol appearing in a theorem statement, proof step, or displayed formula must have a formal definition or explicit introduction earlier in the document (not in a later remark or footnote). Check that every LaTeX macro used in theorem environments is either a standard math symbol or explicitly defined in the preamble or body before its first theorem-context use. Cross-section symbol bookkeeping (single definition site, back-references after gaps) is handled by `math-notation-consistency` once available. R-J owns completeness of theorem statements; `math-notation-consistency` owns cross-section consistency.
+Every symbol appearing in a theorem statement, proof step, or displayed formula must have a formal definition or explicit introduction earlier in the document (not in a later remark or footnote). Check that every LaTeX macro used in theorem environments is either a standard math symbol or explicitly defined in the preamble or body before its first theorem-context use. Cross-section symbol bookkeeping (single definition site, back-references after gaps) is handled by `math-notation-consistency`. R-J owns completeness of theorem statements; `math-notation-consistency` owns cross-section consistency.
 
 **R-K — Standing assumption inheritance.**
-When a section or theorem relies on standing assumptions declared earlier (e.g., "throughout this section, X is a finite metric space with property P"), every theorem in that section must either inherit those assumptions explicitly or state explicitly that it holds without them. After a structural revision (reordering sections, splitting a theorem), check that standing assumptions have not been silently dropped or silently over-applied. Flag any theorem whose hypothesis list differs from the standing assumptions without explanation.
+When a section or theorem relies on standing assumptions declared earlier (e.g., "throughout this section, X is a compact metric space"), every theorem in that section must either inherit those assumptions explicitly or state explicitly that it holds without them. After a structural revision (reordering sections, splitting a theorem), check that standing assumptions have not been silently dropped or silently over-applied. Flag any theorem whose hypothesis list differs from the standing assumptions without explanation.
 
 **R-L — No undefined relation symbols or coined terms in claims.**
-Every relation symbol (≺, ⊏, ⋖, an arrow used as an ordering, or any ad hoc comparative notation) and every coined comparative term ("階層", "検出力の順", "strictly finer/coarser than") that appears in the abstract, introduction, or conclusion must either (a) have a formal definition in the body before (or explicitly referenced at) the point of use, or (b) be replaced by the explicit logical statement it abbreviates. The standard unpacking of "invariant I₁ is strictly coarser than I₂" is: every pair distinguished by I₁ is distinguished by I₂, and there exists a pair on which I₁ agrees while I₂ differs — state both halves with references to the theorems that prove them. An undefined ≺ in a summary section is BLOCKING even when the intended meaning is guessable, because the reader cannot verify the claim against a definition. Division of labour: `math-notation-consistency` NC-1 owns the bookkeeping of definition sites; R-L owns the requirement that abstract/intro/conclusion claims be expressible entirely in defined terms.
+Every relation symbol (≺, ⊏, ⋖, an arrow used as an ordering, or any ad hoc comparative notation) and every coined comparative term ("strictly finer/coarser than", "detection power", or an equivalent coinage in any language) that appears in the abstract, introduction, or conclusion must either (a) have a formal definition in the body before (or explicitly referenced at) the point of use, or (b) be replaced by the explicit logical statement it abbreviates. The standard unpacking of "invariant I₁ is strictly coarser than I₂" is: every pair distinguished by I₁ is distinguished by I₂, and there exists a pair on which I₁ agrees while I₂ differs — state both halves with references to the theorems that prove them. An undefined ≺ in a summary section is BLOCKING even when the intended meaning is guessable, because the reader cannot verify the claim against a definition. Division of labour: `math-notation-consistency` NC-1 owns the bookkeeping of definition sites; R-L owns the requirement that abstract/intro/conclusion claims be expressible entirely in defined terms.
 
 ## Examples
 
 ```
-Before: S_r は等長不変量である．
-After:  S_r は配置 E を入力とする Fourier 座標であり，配置によって変化する（等長不変量ではない）．
+R-I — Before: φ_r is an invariant of X.
+      After:  φ_r depends on the choice of basis used to compute it; it is a
+              coordinate, not an invariant of X.
 ```
 
 ```
-Before: Magnitude は各 t > 0 で定義される．
-After:  Magnitude は Z_X(t) が正則となる t において定義される．
+R-B — Before: The quantity M(t) is defined for every t > 0.
+      After:  M(t) is defined for every t > 0 at which A(t) is invertible.
 ```
 
 ```
-Before: [In §1 contributions list] Theorem A, Theorem B, Theorem C are proved.
-        [In body] Theorem C is used only in the proof of Theorem B.
-After:  [In §1] Theorem B (main result) is proved, using Proposition C as infrastructure.
+R-F — Before: [In §1 contributions list] Theorem A, Theorem B, Theorem C are proved.
+              [In body] Theorem C is used only in the proof of Theorem B.
+      After:  [In §1] Theorem B (main result) is proved, using Proposition C as
+              infrastructure.
 ```
 
 ```
-Before: グリッドサーチにより，α β − 3(γ−δ)² < 0 が確認された。
-After:  [NUMERICAL/coarse-grid] グリッドサーチにより α β − 3(γ−δ)² < 0 を観察した。
-        厳密な証明は §3 の解析的議論による。
+R-D — Before: A grid search confirmed that f(θ) < 0 for all θ in the parameter region.
+      After:  [NUMERICAL/coarse-grid] A grid search observed f(θ) < 0 on the sampled
+              points; the rigorous proof is the analytic argument in §3.
 ```
 
 ```
-Before: The general case remains open.
-        [Later in the same paper] Theorem 4.1 (General case): ...
-After:  [Remove the "remains open" claim; update all cross-references to point to Theorem 4.1.]
+R-E — Before: The general case remains open.
+              [Later in the same paper] Theorem 4.1 (General case): ...
+      After:  [Remove the "remains open" claim; update all cross-references to point
+              to Theorem 4.1.]
 ```
 
 ```
-Before: ゼータ行列から読める不変量は magnitude ≺ ν₋ ≺ σ ≺ 等長型 と階層化される。
-        （≺ は本文のどこでも定義されていない）
-After:  magnitude，ν₋ プロファイル，σ，等長型は，この順に配置を真に細かく区別する．
-        すなわち，隣接する各対について，前者が一致し後者が異なる配置対が存在する（定理 6.5）．
+R-L — Before: The invariants are ordered I₁ ≺ I₂ ≺ I₃. (≺ never defined anywhere)
+      After:  I₁, I₂, I₃ distinguish strictly more pairs in this order: for each
+              adjacent pair, every instance distinguished by the former is
+              distinguished by the latter (Prop. 5.2), and an instance exists on
+              which the former agrees while the latter differs (Thm. 6.5).
 ```
 
 ## Output

--- a/skills/math-notation-consistency/SKILL.md
+++ b/skills/math-notation-consistency/SKILL.md
@@ -1,7 +1,11 @@
 ---
 name: math-notation-consistency
-description: Audit a LaTeX mathematics document for notation drift — symbols used under different names across sections, orphaned macros, undeclared aliases (including cross-language pairs such as 平衡/balanced), symbols or relation signs used with no definition site anywhere, symbol reuse across scopes, and first-use-after-gap without back-reference — without evaluating mathematical correctness or prose style.
+description: Audit a LaTeX mathematics document for notation drift — symbols used under different names across sections, orphaned macros, undeclared aliases (including cross-language pairs where a term defined in one language is later used in another), symbols or relation signs used with no definition site anywhere, symbol reuse across scopes, and first-use-after-gap without back-reference — without evaluating mathematical correctness or prose style.
 ---
+
+# Math Notation Consistency
+
+Audit a LaTeX mathematics document for internal notation consistency. The skill is field-agnostic and applies to documents in any language; it checks bookkeeping (definition sites, aliases, scopes, cross-references), not mathematical correctness or stylistic convention.
 
 ## Use when
 
@@ -9,11 +13,11 @@ description: Audit a LaTeX mathematics document for notation drift — symbols u
 - A symbol or operator appears in a theorem but its definition is not clearly locatable
 - Two LaTeX macros in the preamble appear to define the same object (e.g., `\R` and `\Reals` both for ℝ)
 - A macro is defined in the preamble but never used in the document
-- A named concept (e.g., "small-scale limit", "SSL", "L(u)", "R") has multiple aliases without a declared equivalence
+- A named concept has accumulated multiple aliases (a full name, an abbreviation, and one or more symbols) without a declared equivalence
 - A symbol introduced in section 2 reappears in section 5 with no reminder of its definition
 - The same symbol is used for two different objects (e.g., r as a parameter in one section and as an index in another)
 - A relation symbol or operator (e.g., ≺) appears only in the abstract or conclusion with no definition site anywhere in the body
-- A defined Japanese term and an English word are used interchangeably for the same concept (e.g., 平衡 vs balanced/unbalanced), or the same operator is written with two argument conventions (e.g., Mag(X,t) vs Mag(tX))
+- A term defined in the document's main language is later used in another language for the same concept (e.g., a defined Japanese term later written in English), or the same operator is written with two argument conventions (e.g., F(X,t) vs F(tX))
 
 ## Do not use
 
@@ -31,7 +35,7 @@ description: Audit a LaTeX mathematics document for notation drift — symbols u
 ## Procedure
 
 1. Extract all `\newcommand`, `\renewcommand`, `\DeclareMathOperator` definitions from the preamble; build a macro-definition table.
-2. Extract all first-use-in-prose definitions (e.g., 「\(p_r = |S_r|^2\) と書く」, 「\(X\) を有限距離空間とする」); note section and location.
+2. Extract all first-use-in-prose definitions (e.g., "let X denote …", 「\(f\) を〜とおく」); note section and location.
 3. For each macro in the definition table, check whether it appears in the document body; flag unused macros (NC-2).
 4. For each mathematical symbol appearing in a theorem statement or proof, check that it has a formal definition site earlier in the document (NC-1).
    Also scan the abstract and conclusion for symbols — especially relation symbols such as ≺, ⊏ — that have no definition site anywhere in the document (NC-1, BLOCKING).
@@ -45,19 +49,19 @@ description: Audit a LaTeX mathematics document for notation drift — symbols u
 ## Rules
 
 **NC-1 — One formal definition site per symbol.**
-Every mathematical symbol used in the document must have exactly one formal definition site: either a `\newcommand` in the preamble with a corresponding prose definition in the body, or an explicit inline definition ("let X denote…", "〜を X とおく"). A symbol with two definition sites (e.g., re-defined partway through the paper) is flagged BLOCKING. Note: NC-1 governs the *existence and uniqueness* of the definition; `math-claim-integrity` rule R-J governs whether a symbol is defined *before* its first use in a theorem statement.
+Every mathematical symbol used in the document must have exactly one formal definition site: either a `\newcommand` in the preamble with a corresponding prose definition in the body, or an explicit inline definition ("let X denote…", 「〜を X とおく」). A symbol with two definition sites (e.g., re-defined partway through the paper) is flagged BLOCKING. Note: NC-1 governs the *existence and uniqueness* of the definition; `math-claim-integrity` rule R-J governs whether a symbol is defined *before* its first use in a theorem statement.
 
 **NC-2 — No orphaned macros.**
 Every macro defined in the LaTeX preamble via `\newcommand` or `\DeclareMathOperator` must appear at least once in the document body. A macro defined but never used is dead code that may represent a superseded notation — flag it for removal or documentation. Severity: MINOR.
 
 **NC-3 — One canonical term per concept.**
-Every named mathematical concept must have one canonical term used consistently across the document. If an object is referred to by multiple names (e.g., "small-scale limit", "SSL", "L(u)", and "R" all for the same quantity), each name must appear in a declared-equivalence sentence ("以下では R = lim_{t→0+} |tX| を小スケール極限と呼ぶ"). Without such a declaration, aliases are flagged as NC-3 MINOR findings. Cross-language aliases are a common revision artifact and fall under this rule: a concept defined with a Japanese term (平衡条件) later referred to by an undeclared English word (balanced / unbalanced), or vice versa, is an NC-3 finding — unify to the defined term. Argument-convention variants of the same operator (Mag(X,t) in the definition vs Mag(tX) in a later section) are also NC-3 findings unless the second form is explicitly declared (e.g., tX as the scaled space with Mag(tX) := Mag(X,t)). This rule works in tandem with `math-claim-integrity` rule R-I: R-I checks conceptual *correctness* of the name at introduction; NC-3 checks *consistency* of the name thereafter.
+Every named mathematical concept must have one canonical term used consistently across the document. If an object is referred to by multiple names (a full name, an abbreviation, and a symbol), each name must appear in a declared-equivalence sentence ("we write R for the small-scale limit and abbreviate it SSL"). Without such a declaration, aliases are flagged as NC-3 MINOR findings. Cross-language aliases are a common revision artifact and fall under this rule: a concept defined with a term in the document's main language later referred to by an undeclared equivalent in another language (e.g., a defined Japanese term later written in English, or vice versa) is an NC-3 finding — unify to the defined term. Argument-convention variants of the same operator (F(X,t) in the definition vs F(tX) in a later section) are also NC-3 findings unless the second form is explicitly declared (e.g., tX as the rescaled object with F(tX) := F(X,t)). This rule works in tandem with `math-claim-integrity` rule R-I: R-I checks conceptual *correctness* of the name at introduction; NC-3 checks *consistency* of the name thereafter.
 
 **NC-4 — No symbol reuse across scopes.**
-The same symbol (same LaTeX command or same rendered character) must not be used for two different mathematical objects within any live scope. Common violations: r used as both a continuous parameter and a discrete index; C used as both a constant and a specific matrix; n as both dimension and an index. When a symbol is deliberately reused in a new scope (e.g., a local variable in a proof), the new introduction must explicitly shadow the old one ("この証明中のみ r を〜とおく").
+The same symbol (same LaTeX command or same rendered character) must not be used for two different mathematical objects within any live scope. Common violations: r used as both a continuous parameter and a discrete index; C used as both a constant and a specific matrix; n as both dimension and an index. When a symbol is deliberately reused in a new scope (e.g., a local variable in a proof), the new introduction must explicitly shadow the old one ("in this proof only, let r denote …").
 
 **NC-5 — Back-reference after section gap.**
-When a symbol is first defined in section M and reused in section N where N ≥ M+2, the first reuse in section N should include a back-reference to the definition (e.g., "（定義 2.3 の記号を用いる）", "（式 (3) の S_r）"). Flag first-reuse sites that lack any back-reference. Severity: MINOR. The gap threshold is two or more sections (not two pages or two paragraphs).
+When a symbol is first defined in section M and reused in section N where N ≥ M+2, the first reuse in section N should include a back-reference to the definition (e.g., "(with the notation of Definition 2.3)", "(the S of equation (3))"). Flag first-reuse sites that lack any back-reference. Severity: MINOR. The gap threshold is two or more sections (not two pages or two paragraphs).
 
 **NC-6 — No dangling cross-references.**
 Every `\ref{label}`, `\eqref{label}`, `\autoref{label}` must resolve to a `\label{label}` defined elsewhere in the same document. After reordering sections or renaming theorem environments, dangling references are common. Severity: BLOCKING (since they produce "??" in the compiled PDF and may silently misdirect readers in draft form).
@@ -68,17 +72,16 @@ For a family of related objects, subscript and superscript placement must be con
 ## Examples
 
 ```
-NC-1 example (undefined relation symbol in summary prose):
-Conclusion: 「不変量は magnitude ≺ ν₋ ≺ σ ≺ 等長型 と並ぶ」 — ≺ has no definition
-site anywhere in the document.
+NC-1 (undefined relation symbol in summary prose):
+Conclusion: "the invariants are ordered I₁ ≺ I₂ ≺ I₃" — ≺ has no definition site
+anywhere in the document.
 Finding (BLOCKING): relation symbol ≺ used without a formal definition. Either define
-         the order in the body, or replace with the explicit implication it abbreviates
-         (「隣接する各対について，前者が一致し後者が異なる配置対が存在する」).
+         the order in the body, or replace with the explicit statement it abbreviates.
          Report the conclusion-level claim also to math-claim-integrity rule R-L.
 ```
 
 ```
-NC-2 example:
+NC-2:
 Preamble defines: \newcommand{\Reals}{\mathbb R}
 Body uses only:   \R (defined separately as \newcommand{\R}{\mathbb R})
 Finding: \Reals is orphaned — defined but never used. Either remove \Reals or
@@ -86,43 +89,41 @@ Finding: \Reals is orphaned — defined but never used. Either remove \Reals or
 ```
 
 ```
-NC-3 example:
-Section 2: 「small-scale limit を R と書く」
-Section 4: 「小スケール極限 L(u) は…」  (using L(u) without declaring it equals R)
-Section 6: 「SSL の値として…」           (using SSL without declaring it equals R)
-Finding: Three aliases for the same quantity (R, L(u), SSL) without declared equivalence.
-         Add: 「本稿では R = L(u) = lim_{t→0+} |tX| を小スケール極限 (SSL) と呼ぶ。」
+NC-3 (accumulated aliases):
+Section 2: "we write R for the small-scale limit"
+Section 4: "the limit L(u) satisfies …"   (L(u) never declared equal to R)
+Section 6: "the SSL value is …"           (SSL never declared)
+Finding: Three aliases for the same quantity (R, L(u), SSL) without declared
+         equivalence. Add a single declaration sentence and unify.
 ```
 
 ```
-NC-3 example (cross-language alias):
-Section 2: 「条件 2μ₁ = (n−1)(α+β) を平衡条件と呼ぶ」
-Conclusion: 「unbalanced な組により実現する」「balanced 計量における極」
+NC-3 (cross-language alias):
+Section 2: 「条件 (3) を平衡条件と呼ぶ」
+Conclusion: "the unbalanced case", "in the balanced regime"
 Finding: 平衡/balanced and 非平衡/unbalanced are undeclared alias pairs for the same
-         defined concept. Unify to the defined terms 平衡／非平衡（平衡条件を満たさない）.
+         defined concept. Unify to the defined terms.
 ```
 
 ```
-NC-4 example:
-Section 1: r ∈ ℤ/nℤ is defined as the Fourier index (continuous parameter over n values)
+NC-4:
+Section 1: r is defined as a continuous radius parameter
 Section 3: "let r be a root of the characteristic polynomial" (r as a fresh variable)
 Finding: r reused without explicit shadowing. In section 3, rename to ρ or add
-         「この証明中のみ r を特性多項式の根とおく」.
+         "in this proof only, let r denote a root of …".
 ```
 
 ```
-NC-6 example:
-\eqref{eq:magnitude-def} appears in section 4, but the label \label{eq:magnitude-def}
-was removed when the equation was merged into a displayed block labeled \label{eq:mag}.
-Finding (BLOCKING): dangling reference \eqref{eq:magnitude-def} — update to \eqref{eq:mag}.
+NC-6:
+\eqref{eq:main-def} appears in section 4, but the label \label{eq:main-def} was
+removed when the equation was merged into a displayed block labeled \label{eq:def}.
+Finding (BLOCKING): dangling reference \eqref{eq:main-def} — update to \eqref{eq:def}.
 ```
 
 ```
-NC-7 example:
-Section 2: ν_- (negative inertia index, subscript minus)
-Section 5: ν⁻ (same quantity, minus as superscript)
-Finding: Inconsistent placement. Unify to ν_- (subscript) throughout, matching the
-         \nm macro definition in the preamble.
+NC-7:
+Section 2: ν_- (subscript minus)   Section 5: ν⁻ (same quantity, superscript minus)
+Finding: Inconsistent placement. Unify to the form matching the preamble macro.
 ```
 
 ## Output

--- a/skills/math-notation-consistency/SKILL.md
+++ b/skills/math-notation-consistency/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: math-notation-consistency
+description: Audit a LaTeX mathematics document for notation drift — symbols used under different names across sections, orphaned macros, undeclared aliases (including cross-language pairs such as 平衡/balanced), symbols or relation signs used with no definition site anywhere, symbol reuse across scopes, and first-use-after-gap without back-reference — without evaluating mathematical correctness or prose style.
+---
+
+## Use when
+
+- A LaTeX math paper has been through multiple revisions and may have notation drift (same object referred to by two names in different sections)
+- A symbol or operator appears in a theorem but its definition is not clearly locatable
+- Two LaTeX macros in the preamble appear to define the same object (e.g., `\R` and `\Reals` both for ℝ)
+- A macro is defined in the preamble but never used in the document
+- A named concept (e.g., "small-scale limit", "SSL", "L(u)", "R") has multiple aliases without a declared equivalence
+- A symbol introduced in section 2 reappears in section 5 with no reminder of its definition
+- The same symbol is used for two different objects (e.g., r as a parameter in one section and as an index in another)
+- A relation symbol or operator (e.g., ≺) appears only in the abstract or conclusion with no definition site anywhere in the body
+- A defined Japanese term and an English word are used interchangeably for the same concept (e.g., 平衡 vs balanced/unbalanced), or the same operator is written with two argument conventions (e.g., Mag(X,t) vs Mag(tX))
+
+## Do not use
+
+- For evaluating whether a notation choice is mathematically optimal or conventional — this skill checks internal consistency, not external convention
+- For quantifier scope errors, theorem hierarchy, or proof/computation distinction — use `math-claim-integrity`
+- For Japanese-language anti-patterns — use `wabun-math-style`
+- For prose inflation — use `deslop-prose`
+
+## Inputs
+
+- `artifact` — the LaTeX source file (full document preferred; section range accepted)
+- `preamble` — the LaTeX preamble (if separate; otherwise included in artifact)
+- `known_aliases` — a list of intentional synonyms the author has declared equivalent (optional; if omitted, any alias is flagged)
+
+## Procedure
+
+1. Extract all `\newcommand`, `\renewcommand`, `\DeclareMathOperator` definitions from the preamble; build a macro-definition table.
+2. Extract all first-use-in-prose definitions (e.g., 「\(p_r = |S_r|^2\) と書く」, 「\(X\) を有限距離空間とする」); note section and location.
+3. For each macro in the definition table, check whether it appears in the document body; flag unused macros (NC-2).
+4. For each mathematical symbol appearing in a theorem statement or proof, check that it has a formal definition site earlier in the document (NC-1).
+   Also scan the abstract and conclusion for symbols — especially relation symbols such as ≺, ⊏ — that have no definition site anywhere in the document (NC-1, BLOCKING).
+5. Scan for multiple names applied to the same object (NC-3); compare against `known_aliases` if provided.
+6. Scan for the same symbol applied to different objects across the document's live scopes (NC-4).
+7. For each symbol whose definition site and first re-use are separated by more than one section, flag for back-reference check (NC-5).
+8. Scan `\ref`, `\eqref`, `\autoref` for labels that do not match any defined `\label` in the document (NC-6).
+9. Scan subscript/superscript conventions for the same family of objects; flag inconsistent mixtures (NC-7).
+10. Produce a structured finding report.
+
+## Rules
+
+**NC-1 — One formal definition site per symbol.**
+Every mathematical symbol used in the document must have exactly one formal definition site: either a `\newcommand` in the preamble with a corresponding prose definition in the body, or an explicit inline definition ("let X denote…", "〜を X とおく"). A symbol with two definition sites (e.g., re-defined partway through the paper) is flagged BLOCKING. Note: NC-1 governs the *existence and uniqueness* of the definition; `math-claim-integrity` rule R-J governs whether a symbol is defined *before* its first use in a theorem statement.
+
+**NC-2 — No orphaned macros.**
+Every macro defined in the LaTeX preamble via `\newcommand` or `\DeclareMathOperator` must appear at least once in the document body. A macro defined but never used is dead code that may represent a superseded notation — flag it for removal or documentation. Severity: MINOR.
+
+**NC-3 — One canonical term per concept.**
+Every named mathematical concept must have one canonical term used consistently across the document. If an object is referred to by multiple names (e.g., "small-scale limit", "SSL", "L(u)", and "R" all for the same quantity), each name must appear in a declared-equivalence sentence ("以下では R = lim_{t→0+} |tX| を小スケール極限と呼ぶ"). Without such a declaration, aliases are flagged as NC-3 MINOR findings. Cross-language aliases are a common revision artifact and fall under this rule: a concept defined with a Japanese term (平衡条件) later referred to by an undeclared English word (balanced / unbalanced), or vice versa, is an NC-3 finding — unify to the defined term. Argument-convention variants of the same operator (Mag(X,t) in the definition vs Mag(tX) in a later section) are also NC-3 findings unless the second form is explicitly declared (e.g., tX as the scaled space with Mag(tX) := Mag(X,t)). This rule works in tandem with `math-claim-integrity` rule R-I: R-I checks conceptual *correctness* of the name at introduction; NC-3 checks *consistency* of the name thereafter.
+
+**NC-4 — No symbol reuse across scopes.**
+The same symbol (same LaTeX command or same rendered character) must not be used for two different mathematical objects within any live scope. Common violations: r used as both a continuous parameter and a discrete index; C used as both a constant and a specific matrix; n as both dimension and an index. When a symbol is deliberately reused in a new scope (e.g., a local variable in a proof), the new introduction must explicitly shadow the old one ("この証明中のみ r を〜とおく").
+
+**NC-5 — Back-reference after section gap.**
+When a symbol is first defined in section M and reused in section N where N ≥ M+2, the first reuse in section N should include a back-reference to the definition (e.g., "（定義 2.3 の記号を用いる）", "（式 (3) の S_r）"). Flag first-reuse sites that lack any back-reference. Severity: MINOR. The gap threshold is two or more sections (not two pages or two paragraphs).
+
+**NC-6 — No dangling cross-references.**
+Every `\ref{label}`, `\eqref{label}`, `\autoref{label}` must resolve to a `\label{label}` defined elsewhere in the same document. After reordering sections or renaming theorem environments, dangling references are common. Severity: BLOCKING (since they produce "??" in the compiled PDF and may silently misdirect readers in draft form).
+
+**NC-7 — Consistent subscript/superscript conventions.**
+For a family of related objects, subscript and superscript placement must be consistent. Example: if eigenvalues are written λ_r in most places but λ^r in one section, flag the inconsistency. Similarly, ν_- and ν⁻ (minus as subscript vs. superscript) for the same object must be unified. Severity: MINOR.
+
+## Examples
+
+```
+NC-1 example (undefined relation symbol in summary prose):
+Conclusion: 「不変量は magnitude ≺ ν₋ ≺ σ ≺ 等長型 と並ぶ」 — ≺ has no definition
+site anywhere in the document.
+Finding (BLOCKING): relation symbol ≺ used without a formal definition. Either define
+         the order in the body, or replace with the explicit implication it abbreviates
+         (「隣接する各対について，前者が一致し後者が異なる配置対が存在する」).
+         Report the conclusion-level claim also to math-claim-integrity rule R-L.
+```
+
+```
+NC-2 example:
+Preamble defines: \newcommand{\Reals}{\mathbb R}
+Body uses only:   \R (defined separately as \newcommand{\R}{\mathbb R})
+Finding: \Reals is orphaned — defined but never used. Either remove \Reals or
+         replace \R with \Reals for a single canonical macro.
+```
+
+```
+NC-3 example:
+Section 2: 「small-scale limit を R と書く」
+Section 4: 「小スケール極限 L(u) は…」  (using L(u) without declaring it equals R)
+Section 6: 「SSL の値として…」           (using SSL without declaring it equals R)
+Finding: Three aliases for the same quantity (R, L(u), SSL) without declared equivalence.
+         Add: 「本稿では R = L(u) = lim_{t→0+} |tX| を小スケール極限 (SSL) と呼ぶ。」
+```
+
+```
+NC-3 example (cross-language alias):
+Section 2: 「条件 2μ₁ = (n−1)(α+β) を平衡条件と呼ぶ」
+Conclusion: 「unbalanced な組により実現する」「balanced 計量における極」
+Finding: 平衡/balanced and 非平衡/unbalanced are undeclared alias pairs for the same
+         defined concept. Unify to the defined terms 平衡／非平衡（平衡条件を満たさない）.
+```
+
+```
+NC-4 example:
+Section 1: r ∈ ℤ/nℤ is defined as the Fourier index (continuous parameter over n values)
+Section 3: "let r be a root of the characteristic polynomial" (r as a fresh variable)
+Finding: r reused without explicit shadowing. In section 3, rename to ρ or add
+         「この証明中のみ r を特性多項式の根とおく」.
+```
+
+```
+NC-6 example:
+\eqref{eq:magnitude-def} appears in section 4, but the label \label{eq:magnitude-def}
+was removed when the equation was merged into a displayed block labeled \label{eq:mag}.
+Finding (BLOCKING): dangling reference \eqref{eq:magnitude-def} — update to \eqref{eq:mag}.
+```
+
+```
+NC-7 example:
+Section 2: ν_- (negative inertia index, subscript minus)
+Section 5: ν⁻ (same quantity, minus as superscript)
+Finding: Inconsistent placement. Unify to ν_- (subscript) throughout, matching the
+         \nm macro definition in the preamble.
+```
+
+## Output
+
+Default: review-only. Produce a finding report listing:
+- Rule tag (NC-1 through NC-7)
+- Severity: BLOCKING (NC-1 multi-definition, NC-6 dangling refs) / MINOR (NC-2, NC-3, NC-5, NC-7) / ADVISORY (NC-4 when shadowing is arguable)
+- Location: line number, section heading, or macro name
+- One-sentence description
+- Concrete fix suggestion
+
+When the user asks to apply fixes: edit the LaTeX source in-place for NC-6 (dangling refs) and NC-7 (subscript unification) only — these are purely mechanical. For NC-1/NC-3/NC-4, produce a fix suggestion but do not edit without author confirmation, since renaming a symbol requires global replace.
+
+## Quality Check
+
+Before finishing, verify:
+- NC-6 is checked against the *current* document's `\label` set, not a cached or partial read
+- NC-2 findings distinguish unused macros from macros used only in other macros (a macro used only inside another `\newcommand` is technically "used" even if not directly in prose)
+- NC-3 findings do not flag declared equivalences (where the author explicitly stated the alias)
+- NC-4 findings do not flag standard multi-use notation (e.g., i as imaginary unit in one context and index in another within separate, non-overlapping sections) — only flag within a live scope
+
+## Relationship to Other Skills
+
+- Use `math-claim-integrity` for logical/structural issues: quantifier scope, theorem hierarchy, stale claims, proof/computation distinction. Rule R-I in that skill handles conceptual correctness of a symbol's *name at introduction*; NC-3 here handles consistency of that name *across the document*.
+- Use `wabun-math-style` for Japanese-language anti-patterns.
+- Use `deslop-prose` for prose inflation.
+- NC-1 (existence/uniqueness of definition) complements `math-claim-integrity` rule R-J (defined-before-use in theorem statements): R-J checks completeness of theorem statements; NC-1 checks uniqueness of the definition site.

--- a/skills/wabun-math-style/SKILL.md
+++ b/skills/wabun-math-style/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wabun-math-style
-description: Detect and correct Japanese-language anti-patterns in mathematical writing — epistemic hedges weakening proved claims, incorrect verb tense, passive/active confusion in proofs, ambiguous particles, unjustified 明らか, decorative connectives, redundant meta-discourse, double negation, stacked の, generic/general conflation, borrowed non-mathematical vocabulary (証人・機構・検出・層別・統計量 and the like), and full-width semicolons or untranslated English mixed into Japanese prose — without evaluating mathematical correctness or structural hierarchy.
+description: Detect and correct Japanese-language anti-patterns in mathematical writing — epistemic hedges weakening proved claims, incorrect verb tense, passive/active confusion in proofs, ambiguous particles, unjustified 明らか, decorative connectives, redundant meta-discourse, double negation, stacked の, generic/general conflation, borrowed non-mathematical vocabulary (証人・機構・検出・層別・統計量 and the like), vague category names for explicit formulas (閉形式), and full-width semicolons or untranslated English mixed into Japanese prose — without evaluating mathematical correctness or structural hierarchy.
 ---
 
 # Wabun Math Style
@@ -18,6 +18,7 @@ A language-review skill for Japanese mathematics writing. It targets the class o
 - A sentence has four or more stacked の, obscuring the main predicate
 - 「一般的な」or 「一般の」is used as a translation of the technical term "generic" (holds outside a proper closed subset or measure-zero set) — conflation with the non-technical "general"
 - Vocabulary borrowed from physics, engineering, statistics, or machine learning (証人, 模型, 機構, 装置, 異常, 感知, 検出, 統計量, 層別, 帳簿, 病理, 余裕 …) appears in mathematical prose
+- 「閉形式」(closed form) is used as a category name for a formula that the document states explicitly — instead of naming the formula by equation reference or calling it 明示式
 - Full-width semicolons 「；」appear in Japanese prose, or English words (balanced, unbalanced, genuine, strictness …) are mixed in where a defined Japanese term exists
 
 ## Do not use
@@ -48,7 +49,8 @@ A language-review skill for Japanese mathematics writing. It targets the class o
 11. Scan for 「一般的な」/「一般の」used in a technical-generic sense (JP-12).
 12. Scan for borrowed non-mathematical vocabulary and metaphors (JP-13).
 13. Scan for full-width semicolons and untranslated English terms with defined Japanese equivalents (JP-14).
-14. Produce a structured finding report.
+14. Scan every occurrence of 閉形式 (JP-15); classify as vague category name vs. exempt established term.
+15. Produce a structured finding report.
 
 ## Rules
 
@@ -115,6 +117,14 @@ Do NOT flag established mathematical terms whose surface form coincides with eve
 
 **JP-14 — 全角セミコロン・未翻訳英語の混在禁止．**
 和文の数学散文では全角セミコロン「；」を用いない．並列・対比は読点・句点または文の分割で表し，enumerate 項目末尾も句点で終える．また，本文で和訳語を定義した概念（例：平衡条件）を英語のまま（balanced / unbalanced）併用しない — this creates an undeclared alias (report it also as NC-3 to `math-notation-consistency`). English adjectives such as genuine, strictness must not qualify Japanese nouns bare; unpack the intended condition in Japanese（e.g., 「genuine な極」→「分子が同時に零にならない極」）. Terms with no established Japanese translation that the document itself introduces (magnitude, homometric, generic, isospectral …) are exempt. Severity: MINOR for semicolons; BLOCKING for an English alias of a defined Japanese term in a theorem statement or summary of results.
+
+**JP-15 — 範疇名「閉形式」の禁止（明示式・明示計算への置換）．**
+「閉形式」(closed form) は *どの* 形かを述べない範疇名であり，指示対象の式を文書自身が明示的に与えている場合には用いない．「閉形式」と書くたびに読者は「閉」の境界（初等関数か，有理式か，有限和か）を推測させられるが，式が紙面にあるならその推測は不要である — 式番号で指すか，「明示式」と呼べばよい．The test: does the document display the formula the word points to? If yes, the category name is strictly less informative than the reference. 置換指針:
+- 式そのものを指す名詞用法（「X の閉形式」）→「X の明示式」＋式番号参照（例「magnitude の明示式 \eqref{eq:mag}」），または式そのもの・式番号のみ
+- 「同一の閉形式 X をもつ」→ 何が一致するかを明示（「同一パラメータから定まる同一の X」「明示式 \eqref{…} により同一の X」）
+- 「閉形式で確認する／計算する／一致する」という様態用法 →「明示的に計算して確認する」「直接計算により」「明示式 \eqref{…} として一致する」
+- 定理・命題・補題のタイトル中（「[X の閉形式]」）→「[X の明示式]」．`\label{...}` の内部識別子は変更しない
+誤検出除外: (a) 微分幾何・de Rham 理論の「閉形式」(closed differential form, \(d\omega=0\)) は確立した術語であり対象外（完全形式・コホモロジーが近傍に現れるのが目印）．(b) 閉形式解の存在・非存在それ自体が主題で，文書が「閉形式」の意味を形式的に定義している場合（微分 Galois 理論，Liouville 流の初等関数論など）は対象外．(c) 引用文献のタイトル・定理名に含まれる場合は原文のまま残す．Severity: BLOCKING in theorem/proposition/lemma statements and titles, abstracts, and summaries of results; MINOR elsewhere.
 
 ## Examples
 
@@ -191,10 +201,31 @@ Before（JP-14）: R=1 は unbalanced 証人により実現する；他の場合
 After:          R=1 は平衡条件を満たさない組により実現する。他の場合は平衡条件が必要である。
 ```
 
+```
+Before（JP-15）: \begin{proposition}[magnitude の閉形式]\label{prop:closed}
+After:          \begin{proposition}[magnitude の明示式]\label{prop:closed}
+                （ラベルは変更しない）
+```
+
+```
+Before（JP-15）: 同一の閉形式 magnitude をもつ二配置が存在する。
+After:          同一パラメータから定まる同一の magnitude をもつ二配置が存在する。
+                （または：明示式 \eqref{eq:mag} により同一の magnitude をもつ二配置が存在する。）
+```
+
+```
+Before（JP-15）: この状況を閉形式で確認する。
+After:          この状況を明示的に計算して確認する。
+```
+
+```
+Exempt（JP-15）: ω は閉形式である（dω = 0）。 — closed differential form; do not flag.
+```
+
 ## Output
 
 Default: review-only. Produce a structured finding report listing:
-- Rule tag (JP-1 through JP-14, skipping JP-10 which is merged into JP-3)
+- Rule tag (JP-1 through JP-15, skipping JP-10 which is merged into JP-3)
 - Severity: BLOCKING (epistemic hedge on proved claim, logical-gap connective) / MINOR (verb tense, meta-discourse) / ADVISORY (JP-7 only)
 - Location: environment label (e.g., `\begin{theorem}[thm:main]`), proof section, or paragraph identifier
 - One-sentence description of the violation
@@ -211,6 +242,7 @@ Before finishing, verify:
 - JP-7 findings are all marked ADVISORY
 - JP-13 findings do not flag established mathematical terms that share surface form with everyday or physics words (核, 流, スペクトル, …) — the test is published-journal usage
 - JP-14 findings exempt terms the document itself introduces without an established Japanese translation
+- JP-15 findings do not flag 閉形式 in the differential-form sense (dω = 0), in documents where closed-form solvability is itself the formally defined subject, or inside cited titles
 - No finding belongs to `math-claim-integrity` territory (quantifier scope, theorem hierarchy, proof/computation distinction)
 
 ## Relationship to Other Skills

--- a/skills/wabun-math-style/SKILL.md
+++ b/skills/wabun-math-style/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: wabun-math-style
+description: Detect and correct Japanese-language anti-patterns in mathematical writing — epistemic hedges weakening proved claims, incorrect verb tense, passive/active confusion in proofs, ambiguous particles, unjustified 明らか, decorative connectives, redundant meta-discourse, double negation, stacked の, generic/general conflation, borrowed non-mathematical vocabulary (証人・機構・検出・層別・統計量 and the like), and full-width semicolons or untranslated English mixed into Japanese prose — without evaluating mathematical correctness or structural hierarchy.
+---
+
+# Wabun Math Style
+
+A language-review skill for Japanese mathematics writing. It targets the class of errors that arise specifically in Japanese mathematical prose: epistemic hedges that misrepresent proved claims as uncertain, tense inconsistencies in theorem statements, voice confusion in proof steps, connectives that mark logical steps without logical warrant, bare 明らか/自明/容易に without justification, redundant meta-discourse openers, は/が particle ambiguity in theorem subjects, ならば/とき confusion in conditional hypotheses, double-negation hedging, and の-chains that obscure the main predicate. The skill operates strictly at the language layer and does not evaluate mathematical correctness, quantifier scope, theorem hierarchy, or proof/computation honesty.
+
+## Use when
+
+- A Japanese mathematics paper or preprint (LaTeX with ltjsarticle, jarticle, or similar) needs language review
+- Theorem statements or proof steps contain epistemic hedges (〜と思われる, 〜と考えられる) that weaken what should be unconditional mathematical assertions
+- Connectives (すなわち, ゆえに, よって, したがって) appear without marking genuine logical steps
+- Meta-discourse openers (本節では, 以下では) appear redundantly where the section heading already provides orientation
+- Verb forms are inconsistent — past tense for timeless mathematical facts, or mixed passive/active in the same proof
+- 明らか / 自明 / 容易に appear bare, without adjacent justification
+- A sentence has four or more stacked の, obscuring the main predicate
+- 「一般的な」or 「一般の」is used as a translation of the technical term "generic" (holds outside a proper closed subset or measure-zero set) — conflation with the non-technical "general"
+- Vocabulary borrowed from physics, engineering, statistics, or machine learning (証人, 模型, 機構, 装置, 異常, 感知, 検出, 統計量, 層別, 帳簿, 病理, 余裕 …) appears in mathematical prose
+- Full-width semicolons 「；」appear in Japanese prose, or English words (balanced, unbalanced, genuine, strictness …) are mixed in where a defined Japanese term exists
+
+## Do not use
+
+- For structural issues (theorem hierarchy, quantifier scope errors, proof/computation conflation) — use `math-claim-integrity`
+- For symbol-table consistency — use `math-notation-consistency`
+- For general prose inflation that is not Japanese-specific — use `deslop-prose`
+- For removing process history from planning documents — use `deslop-history`
+
+## Inputs
+
+- `artifact` — the Japanese LaTeX source file or section range
+- `register` — 論文 (formal paper), ノート (preprint/note), or 講義録 (lecture notes); conventions differ slightly
+- `proof_sections` — proof environments where active-voice standards are strictest (optional; defaults to all \begin{proof}...\end{proof} blocks)
+
+## Procedure
+
+1. Scan for epistemic hedge phrases (JP-1); flag each against the claim it modifies.
+2. Scan for verb tense in theorem and proposition statements (JP-2).
+3. Scan proof environments for passive-voice proof steps (JP-3, which subsumes JP-10).
+4. Scan every occurrence of すなわち, ゆえに, よって, したがって (JP-4); verify each signals a deductive step.
+5. Scan for 明らか / 自明 / 容易に (JP-5); check for adjacent justification.
+6. Scan for redundant meta-discourse openers at paragraph and section boundaries (JP-6).
+7. Scan theorem subjects for が/は ambiguity patterns (JP-7, advisory).
+8. Scan lemma hypotheses for ならば vs とき/場合 (JP-8).
+9. Scan for double-negation patterns (JP-9).
+10. Scan for の-chains of length ≥4 (JP-11).
+11. Scan for 「一般的な」/「一般の」used in a technical-generic sense (JP-12).
+12. Scan for borrowed non-mathematical vocabulary and metaphors (JP-13).
+13. Scan for full-width semicolons and untranslated English terms with defined Japanese equivalents (JP-14).
+14. Produce a structured finding report.
+
+## Rules
+
+**JP-1 — Epistemic hedge ban on proved claims.**
+The phrases 〜と思われる, 〜と考えられる, 〜のように見える, 〜らしい, 〜と予想される, 〜はずである must not appear in theorem statements, propositions, lemma statements, or in prose that summarizes what has been proved. In proof environments, they are permitted only inside a \begin{remark}...\end{remark} block that explicitly labels an unproved conjecture. This is the highest-priority rule: an epistemic hedge on a proved claim is a category error that misrepresents the paper's results to the reader.
+
+**JP-2 — Present-tense invariance for mathematical facts.**
+Mathematical statements assert timeless truths and use present tense: 〜する, 〜である, 〜が成り立つ, 〜が存在する. Past tense (〜した, 〜であった, 〜が成り立った) is permitted only for: (a) historical attribution ("Kamiyama は…を示した"), (b) referencing a specific step completed earlier in the same proof ("前節で示したように"). Flag past-tense verbs in theorem and proposition statements.
+
+**JP-3 — Proof-step voice discipline (active for construction; passive only for citation).**
+Within a proof, sentences that construct or advance the argument must use active constructions: 〜を示す, 〜とおく, 〜を用いると, 〜が従う, 〜が成り立つ. The passive 〜が示された / 〜が示されている, 〜が証明された / 〜が証明されている is appropriate only to cite a result proved outside this proof (e.g., in a prior lemma or external paper). The stative/resultative forms 〜が示されている and 〜が証明されている are the natural citation register in formal Japanese mathematical writing (e.g., 「[Kamiyama] により〜が示されている」) and are explicitly permitted alongside the perfective forms. Using passive voice for the conclusion of a proof step that was just carried out here (e.g., "ゆえに P が示された" at the end of a proof that proved P) is acceptable only if the result was actually established by citing an external source; otherwise prefer "ゆえに P が成り立つ" or "以上で P を示した." Note: this rule subsumes the passive-scope restriction; no separate rule for 受動態 is needed.
+
+**JP-4 — Connective discipline.**
+Each logical connective must signal exactly what it claims:
+- すなわち: restatement or clarification of the immediately preceding sentence. Must NOT introduce a new deductive step.
+- ゆえに / よって: conclusion follows by logical necessity from what immediately precedes. Must NOT be used as a mere rhetorical transition or section introduction.
+- したがって: same logical role as よって, more formal register; do not mix both in the same proof without a register reason.
+- つまり: informal restatement; appropriate in notes but not in theorem proofs.
+
+Flag any sentence beginning with ゆえに/よって/したがって that does not actually follow from the immediately preceding text — this marks a logical gap, not merely a style issue.
+
+**JP-5 — Justify 明らか, 自明, 容易に.**
+These words must be followed (in the same sentence or the immediately following sentence) by a one-clause justification or a reference (e.g., "（補題 2.2 より）", "（定義から直接）"). Flag bare uses with no adjacent justification. The test: can a reader verify the claim without looking elsewhere? If the answer involves checking a sign inequality, boundary condition, or multi-step substitution, the claim is not 明らか.
+
+**JP-6 — Flag redundant meta-discourse openers.**
+Flag 本節では〜, 以下では〜, なお〜, ここでは〜 at paragraph openings ONLY when the content is already signposted by the section or subsection heading, or when deleting the opener loses no information ("本節では S_r の性質を述べる。" before a section titled "S_r の性質" is redundant). Do NOT enforce a density quota; one purposeful orientation sentence per section is acceptable. Replace redundant openers with a direct mathematical statement.
+
+**JP-7 — Particle が/は in theorem subjects (advisory).**
+In theorem statements: は marks the subject as the established topic (contrasting with alternatives); が marks the subject as new information or the logical subject of an existential claim. Common error: using は when introducing a new object for the first time, or は in an existential claim ("X は存在する" reads as "as for X, it exists," implying X is already introduced; "X が存在する" correctly asserts existence of a new X). This is an advisory finding (severity: MINOR), not a blocking error, because は/が selection is context-dependent and may be deliberately chosen for emphasis.
+
+**JP-8 — ならば for conditional lemma hypotheses.**
+In lemma and theorem statements, conditional hypotheses must use ならば (or the equivalent formal conditional structure P ⟹ Q), not とき or 場合, which can be read as temporal. "P のとき Q が成り立つ" is acceptable in informal notes but may be ambiguous; "P ならば Q が成り立つ" is unambiguous for a logical conditional. Exception: do NOT flag とき/場合 when it introduces a genuine case-split or parameter range (e.g., 「t > 0 のとき」, 「n が偶数の場合」). Flag JP-8 only when とき/場合 connects a logical hypothesis to a conclusion (P のとき Q が成り立つ, where P is a logical condition, not a range label or case header).
+
+**JP-9 — Double-negation ban.**
+Patterns 〜でないとは言えない, 〜でないわけではない, 〜ないこともない are logically equivalent to "possibly 〜" but read as hedged. In mathematical writing, replace with a direct affirmative ("〜である（場合がある）") or a precise partial statement with explicit quantification. Double negatives in theorem statements are almost always artifacts of draft hedging; eliminate them.
+
+**JP-11 — の-chain limit.**
+A chain of four or more stacked の (possessive/genitive markers) obscures the main predicate and the logical relationships between constituents. Example: 「配置の非依存性の証明の骨子の説明」should be broken into shorter nominal phrases or rewritten with a predicate. Flag any の-chain of length ≥4 and suggest a restructured phrase.
+
+**JP-12 — generic と general の峻別．**
+The technical term "generic" (holds outside a proper closed algebraic subset, outside a measure-zero set, or — in the sense of O'Hara — with rationally independent distances or a non-degeneracy condition) must NOT be expressed as 「一般的な」or 「一般の」. Those Japanese words mean "general / typical / widely applicable" — a non-technical qualification — and do not carry the algebro-geometric or measure-theoretic precision of "generic." Conflation creates a logical error: "一般的な有限距離空間では P が成立する" reads as "P holds for a typical/arbitrary space" (i.e., universally), whereas the intended claim is "P holds for spaces outside a specific degenerate subfamily."
+
+Correct substitutes:
+- **technical generic** → 「generic な」(recommended: preserves the term, unambiguous), or 「一般位置の」(for algebraic-geometry-style general-position conditions), or an explicit description of the non-degeneracy condition
+- **technical non-generic** → 「非 generic な」, 「退化した」(when degeneracy is the focus), or 「特殊な（対称性の高い）」(when special structure is the focus)
+- **non-technical general** → 「一般の」, 「一般的な」remain correct for "for a general [arbitrary representative of the class]"
+
+Severity: BLOCKING when the conflation appears in theorem statements, in the scope of a cited result (e.g., characterising O'Hara's theorem), or in the introduction when the distinction between the generic and degenerate case is the main point. MINOR in expository prose or narrative framing.
+
+**JP-13 — 分野外借用語・比喩の排除．**
+純粋数学の散文では，物理・工学・統計・機械学習に由来する借用語，および物語的・擬人的比喩を用いない．The test: would the word appear, with the same meaning and without a definition, in a published Japanese mathematics journal article? If not, replace it with the precise mathematical object or operation. Representative pairs (the rule targets the whole class, not only this list):
+- 証人（witness）→「明示例」「具体的な配置対」「〜を満たす例」
+- 模型（model, physics sense）→「例」「構成」
+- 機構・装置・回路・エンジン・からくり・仕組み →「構成」「議論の構造」, or delete and state the mechanism directly
+- 異常・病理 →「退化した場合」「反例」
+- 感知する・検出する（検出力を含む）→「区別する」「識別する」
+- 統計量 →「不変量」「量」
+- 層別（する・される）→「分類」「階層」(only when the hierarchy is formally defined)
+- 帳簿・台帳（bookkeeping）→「計数」「対応」
+- 余裕（as a translation of "margin" in an estimate）→「差」, or state the inequality directly
+- 風景・地図・物語・旅・精神（"in the spirit of"）→ delete the metaphor; state the claim or the analogy precisely（e.g., 「〜と同じ精神に立つ」→「〜の有限距離空間における対応物である」）
+
+Do NOT flag established mathematical terms whose surface form coincides with everyday or physics words: 核 (kernel), 流 (flow), スペクトル, 作用素, エネルギー法 (when citing the named method), 安定性. Severity: BLOCKING in theorem statements, abstracts, and introductions; MINOR elsewhere.
+
+**JP-14 — 全角セミコロン・未翻訳英語の混在禁止．**
+和文の数学散文では全角セミコロン「；」を用いない．並列・対比は読点・句点または文の分割で表し，enumerate 項目末尾も句点で終える．また，本文で和訳語を定義した概念（例：平衡条件）を英語のまま（balanced / unbalanced）併用しない — this creates an undeclared alias (report it also as NC-3 to `math-notation-consistency`). English adjectives such as genuine, strictness must not qualify Japanese nouns bare; unpack the intended condition in Japanese（e.g., 「genuine な極」→「分子が同時に零にならない極」）. Terms with no established Japanese translation that the document itself introduces (magnitude, homometric, generic, isospectral …) are exempt. Severity: MINOR for semicolons; BLOCKING for an English alias of a defined Japanese term in a theorem statement or summary of results.
+
+## Examples
+
+```
+Before（JP-1）: したがって ν₋ は配置を区別すると考えられる。
+After:          したがって ν₋ は配置を区別する（系 2.3）。
+```
+
+```
+Before（JP-2）: Z_X(t) は正則行列であった。
+After:          Z_X(t) は正則行列である。
+```
+
+```
+Before（JP-3）: ゆえに補題 2.1 の条件が満たされたことが示された。
+After:          ゆえに補題 2.1 の条件が満たされる。
+                （または，外部補題を引用した場合：「補題 2.1 により条件が満たされていることが示されている。」）
+```
+
+```
+Before（JP-4）: したがって，次節では Fourier 分解を導入する。
+After:          （削除；節の遷移は見出しで十分）
+```
+
+```
+Before（JP-5）: 三角不等式が成立することは明らかである。
+After:          三角不等式は max(α,β) ≤ 2 min(γ,δ) および |γ−δ| ≤ min(α,β) から従う（補題 2.2）。
+```
+
+```
+Before（JP-6）: 本節では S_r の性質を述べる。S_r を次で定義する。[section heading: "S_r の性質"]
+After:          （「本節では…」の行を削除）S_r を次で定義する。
+```
+
+```
+Before（JP-8）: P のとき Q が成り立つ。（補題の仮説として）
+After:          P ならば Q が成り立つ。
+```
+
+```
+Before（JP-9）: この場合，S_r が配置に依存しないとは言えない。
+After:          この場合，S_r は配置に依存する可能性がある。
+                （または確定している場合：「この場合，S_r は配置に依存する。」）
+```
+
+```
+Before（JP-11）: 配置の非依存性の証明の骨子の説明を与える。
+After:           配置非依存性の証明の概略を述べる。
+```
+
+```
+Before（JP-12）: 一般的な有限距離空間では one-point property が成立する。
+                 （O'Hara の有理独立条件を満たす generic な空間に対する結果として書いた場合）
+After:           generic な有限距離空間では one-point property が成立する。
+```
+
+```
+Before（JP-12）: O'Hara の意味で非一般的な（対称性の高い）族
+After:           O'Hara の意味で非 generic な（対称性の高い）族
+```
+
+```
+Before（JP-13）: この配置対が定理の証人である。
+After:          この配置対が定理の主張を満たす明示例である。
+```
+
+```
+Before（JP-13）: ν₋ の検出力は完全に層別される。
+After:          ν₋ が区別する配置対の全体は，閾値超過多重集合により特徴づけられる（定理 6.5）。
+```
+
+```
+Before（JP-14）: R=1 は unbalanced 証人により実現する；他の場合は balance を強制する。
+After:          R=1 は平衡条件を満たさない組により実現する。他の場合は平衡条件が必要である。
+```
+
+## Output
+
+Default: review-only. Produce a structured finding report listing:
+- Rule tag (JP-1 through JP-14, skipping JP-10 which is merged into JP-3)
+- Severity: BLOCKING (epistemic hedge on proved claim, logical-gap connective) / MINOR (verb tense, meta-discourse) / ADVISORY (JP-7 only)
+- Location: environment label (e.g., `\begin{theorem}[thm:main]`), proof section, or paragraph identifier
+- One-sentence description of the violation
+- A concrete rewrite suggestion in Japanese
+
+When the user asks to apply fixes: edit the LaTeX source in-place. Preserve all mathematical content, macro names, and theorem labels. Append a change log with rule tag, location, and before/after text.
+
+## Quality Check
+
+Before finishing, verify:
+- JP-1 findings mark only proved claims, not open problems in remark/conjecture environments
+- JP-3 findings do not flag the legitimate citation passive (〜が示されている, 〜が証明されている + external citation)
+- JP-5 findings include the rewrite suggestion, not just a flag
+- JP-7 findings are all marked ADVISORY
+- JP-13 findings do not flag established mathematical terms that share surface form with everyday or physics words (核, 流, スペクトル, …) — the test is published-journal usage
+- JP-14 findings exempt terms the document itself introduces without an established Japanese translation
+- No finding belongs to `math-claim-integrity` territory (quantifier scope, theorem hierarchy, proof/computation distinction)
+
+## Relationship to Other Skills
+
+- Use `math-claim-integrity` for structural and logical quality issues (quantifier scope, theorem hierarchy, proof/computation honesty, stale claims).
+- Use `math-notation-consistency` for symbol drift, orphaned macros, and alias detection.
+- Use `deslop-prose` for language-agnostic prose inflation (hype, decorative structure, claim-evidence mismatch). Note: `deslop-prose` is language-agnostic; `wabun-math-style` handles Japanese-specific patterns that `deslop-prose` does not target.
+- Use `deslop-history` when a planning or notes document leaks process history or prior-draft residue.

--- a/skills/wabun-math-style/SKILL.md
+++ b/skills/wabun-math-style/SKILL.md
@@ -5,7 +5,7 @@ description: Detect and correct Japanese-language anti-patterns in mathematical 
 
 # Wabun Math Style
 
-A language-review skill for Japanese mathematics writing. It targets the class of errors that arise specifically in Japanese mathematical prose: epistemic hedges that misrepresent proved claims as uncertain, tense inconsistencies in theorem statements, voice confusion in proof steps, connectives that mark logical steps without logical warrant, bare 明らか/自明/容易に without justification, redundant meta-discourse openers, は/が particle ambiguity in theorem subjects, ならば/とき confusion in conditional hypotheses, double-negation hedging, and の-chains that obscure the main predicate. The skill operates strictly at the language layer and does not evaluate mathematical correctness, quantifier scope, theorem hierarchy, or proof/computation honesty.
+A language-review skill for Japanese mathematics writing. It targets the class of errors that arise specifically in Japanese mathematical prose: epistemic hedges that misrepresent proved claims as uncertain, tense inconsistencies in theorem statements, voice confusion in proof steps, connectives that mark logical steps without logical warrant, bare 明らか/自明/容易に without justification, redundant meta-discourse openers, は/が particle ambiguity in theorem subjects, ならば/とき confusion in conditional hypotheses, double-negation hedging, and の-chains that obscure the main predicate. The skill is field-agnostic: the rules apply to any area of mathematics. It operates strictly at the language layer and does not evaluate mathematical correctness, quantifier scope, theorem hierarchy, or proof/computation honesty.
 
 ## Use when
 
@@ -19,7 +19,7 @@ A language-review skill for Japanese mathematics writing. It targets the class o
 - 「一般的な」or 「一般の」is used as a translation of the technical term "generic" (holds outside a proper closed subset or measure-zero set) — conflation with the non-technical "general"
 - Vocabulary borrowed from physics, engineering, statistics, or machine learning (証人, 模型, 機構, 装置, 異常, 感知, 検出, 統計量, 層別, 帳簿, 病理, 余裕 …) appears in mathematical prose
 - 「閉形式」(closed form) is used as a category name for a formula that the document states explicitly — instead of naming the formula by equation reference or calling it 明示式
-- Full-width semicolons 「；」appear in Japanese prose, or English words (balanced, unbalanced, genuine, strictness …) are mixed in where a defined Japanese term exists
+- Full-width semicolons 「；」appear in Japanese prose, or English words (balanced, genuine, strictness …) are mixed in where a defined Japanese term exists
 
 ## Do not use
 
@@ -58,10 +58,10 @@ A language-review skill for Japanese mathematics writing. It targets the class o
 The phrases 〜と思われる, 〜と考えられる, 〜のように見える, 〜らしい, 〜と予想される, 〜はずである must not appear in theorem statements, propositions, lemma statements, or in prose that summarizes what has been proved. In proof environments, they are permitted only inside a \begin{remark}...\end{remark} block that explicitly labels an unproved conjecture. This is the highest-priority rule: an epistemic hedge on a proved claim is a category error that misrepresents the paper's results to the reader.
 
 **JP-2 — Present-tense invariance for mathematical facts.**
-Mathematical statements assert timeless truths and use present tense: 〜する, 〜である, 〜が成り立つ, 〜が存在する. Past tense (〜した, 〜であった, 〜が成り立った) is permitted only for: (a) historical attribution ("Kamiyama は…を示した"), (b) referencing a specific step completed earlier in the same proof ("前節で示したように"). Flag past-tense verbs in theorem and proposition statements.
+Mathematical statements assert timeless truths and use present tense: 〜する, 〜である, 〜が成り立つ, 〜が存在する. Past tense (〜した, 〜であった, 〜が成り立った) is permitted only for: (a) historical attribution (「Euler は〜を示した」), (b) referencing a specific step completed earlier in the same proof (「前節で示したように」). Flag past-tense verbs in theorem and proposition statements.
 
 **JP-3 — Proof-step voice discipline (active for construction; passive only for citation).**
-Within a proof, sentences that construct or advance the argument must use active constructions: 〜を示す, 〜とおく, 〜を用いると, 〜が従う, 〜が成り立つ. The passive 〜が示された / 〜が示されている, 〜が証明された / 〜が証明されている is appropriate only to cite a result proved outside this proof (e.g., in a prior lemma or external paper). The stative/resultative forms 〜が示されている and 〜が証明されている are the natural citation register in formal Japanese mathematical writing (e.g., 「[Kamiyama] により〜が示されている」) and are explicitly permitted alongside the perfective forms. Using passive voice for the conclusion of a proof step that was just carried out here (e.g., "ゆえに P が示された" at the end of a proof that proved P) is acceptable only if the result was actually established by citing an external source; otherwise prefer "ゆえに P が成り立つ" or "以上で P を示した." Note: this rule subsumes the passive-scope restriction; no separate rule for 受動態 is needed.
+Within a proof, sentences that construct or advance the argument must use active constructions: 〜を示す, 〜とおく, 〜を用いると, 〜が従う, 〜が成り立つ. The passive 〜が示された / 〜が示されている, 〜が証明された / 〜が証明されている is appropriate only to cite a result proved outside this proof (e.g., in a prior lemma or external paper). The stative/resultative forms 〜が示されている and 〜が証明されている are the natural citation register in formal Japanese mathematical writing (e.g., 「[12] により〜が示されている」) and are explicitly permitted alongside the perfective forms. Using passive voice for the conclusion of a proof step that was just carried out here (e.g., 「ゆえに P が示された」 at the end of a proof that proved P) is acceptable only if the result was actually established by citing an external source; otherwise prefer 「ゆえに P が成り立つ」 or 「以上で P を示した」. Note: this rule subsumes the passive-scope restriction; no separate rule for 受動態 is needed.
 
 **JP-4 — Connective discipline.**
 Each logical connective must signal exactly what it claims:
@@ -73,36 +73,36 @@ Each logical connective must signal exactly what it claims:
 Flag any sentence beginning with ゆえに/よって/したがって that does not actually follow from the immediately preceding text — this marks a logical gap, not merely a style issue.
 
 **JP-5 — Justify 明らか, 自明, 容易に.**
-These words must be followed (in the same sentence or the immediately following sentence) by a one-clause justification or a reference (e.g., "（補題 2.2 より）", "（定義から直接）"). Flag bare uses with no adjacent justification. The test: can a reader verify the claim without looking elsewhere? If the answer involves checking a sign inequality, boundary condition, or multi-step substitution, the claim is not 明らか.
+These words must be followed (in the same sentence or the immediately following sentence) by a one-clause justification or a reference (e.g., 「（補題 2.2 より）」, 「（定義から直接）」). Flag bare uses with no adjacent justification. The test: can a reader verify the claim without looking elsewhere? If the answer involves checking a sign inequality, boundary condition, or multi-step substitution, the claim is not 明らか.
 
 **JP-6 — Flag redundant meta-discourse openers.**
-Flag 本節では〜, 以下では〜, なお〜, ここでは〜 at paragraph openings ONLY when the content is already signposted by the section or subsection heading, or when deleting the opener loses no information ("本節では S_r の性質を述べる。" before a section titled "S_r の性質" is redundant). Do NOT enforce a density quota; one purposeful orientation sentence per section is acceptable. Replace redundant openers with a direct mathematical statement.
+Flag 本節では〜, 以下では〜, なお〜, ここでは〜 at paragraph openings ONLY when the content is already signposted by the section or subsection heading, or when deleting the opener loses no information (「本節では f の性質を述べる。」 before a section titled 「f の性質」 is redundant). Do NOT enforce a density quota; one purposeful orientation sentence per section is acceptable. Replace redundant openers with a direct mathematical statement.
 
 **JP-7 — Particle が/は in theorem subjects (advisory).**
-In theorem statements: は marks the subject as the established topic (contrasting with alternatives); が marks the subject as new information or the logical subject of an existential claim. Common error: using は when introducing a new object for the first time, or は in an existential claim ("X は存在する" reads as "as for X, it exists," implying X is already introduced; "X が存在する" correctly asserts existence of a new X). This is an advisory finding (severity: MINOR), not a blocking error, because は/が selection is context-dependent and may be deliberately chosen for emphasis.
+In theorem statements: は marks the subject as the established topic (contrasting with alternatives); が marks the subject as new information or the logical subject of an existential claim. Common error: using は when introducing a new object for the first time, or は in an existential claim (「X は存在する」 reads as "as for X, it exists," implying X is already introduced; 「X が存在する」 correctly asserts existence of a new X). This is an advisory finding (severity: MINOR), not a blocking error, because は/が selection is context-dependent and may be deliberately chosen for emphasis.
 
 **JP-8 — ならば for conditional lemma hypotheses.**
-In lemma and theorem statements, conditional hypotheses must use ならば (or the equivalent formal conditional structure P ⟹ Q), not とき or 場合, which can be read as temporal. "P のとき Q が成り立つ" is acceptable in informal notes but may be ambiguous; "P ならば Q が成り立つ" is unambiguous for a logical conditional. Exception: do NOT flag とき/場合 when it introduces a genuine case-split or parameter range (e.g., 「t > 0 のとき」, 「n が偶数の場合」). Flag JP-8 only when とき/場合 connects a logical hypothesis to a conclusion (P のとき Q が成り立つ, where P is a logical condition, not a range label or case header).
+In lemma and theorem statements, conditional hypotheses must use ならば (or the equivalent formal conditional structure P ⟹ Q), not とき or 場合, which can be read as temporal. 「P のとき Q が成り立つ」 is acceptable in informal notes but may be ambiguous; 「P ならば Q が成り立つ」 is unambiguous for a logical conditional. Exception: do NOT flag とき/場合 when it introduces a genuine case-split or parameter range (e.g., 「t > 0 のとき」, 「n が偶数の場合」). Flag JP-8 only when とき/場合 connects a logical hypothesis to a conclusion (P のとき Q が成り立つ, where P is a logical condition, not a range label or case header).
 
 **JP-9 — Double-negation ban.**
-Patterns 〜でないとは言えない, 〜でないわけではない, 〜ないこともない are logically equivalent to "possibly 〜" but read as hedged. In mathematical writing, replace with a direct affirmative ("〜である（場合がある）") or a precise partial statement with explicit quantification. Double negatives in theorem statements are almost always artifacts of draft hedging; eliminate them.
+Patterns 〜でないとは言えない, 〜でないわけではない, 〜ないこともない are logically equivalent to "possibly 〜" but read as hedged. In mathematical writing, replace with a direct affirmative (「〜である（場合がある）」) or a precise partial statement with explicit quantification. Double negatives in theorem statements are almost always artifacts of draft hedging; eliminate them.
 
 **JP-11 — の-chain limit.**
-A chain of four or more stacked の (possessive/genitive markers) obscures the main predicate and the logical relationships between constituents. Example: 「配置の非依存性の証明の骨子の説明」should be broken into shorter nominal phrases or rewritten with a predicate. Flag any の-chain of length ≥4 and suggest a restructured phrase.
+A chain of four or more stacked の (possessive/genitive markers) obscures the main predicate and the logical relationships between constituents. Example: 「解の一意性の証明の方針の説明を与える」 should be broken into shorter nominal phrases or rewritten with a predicate. Flag any の-chain of length ≥4 and suggest a restructured phrase.
 
-**JP-12 — generic と general の峻別．**
-The technical term "generic" (holds outside a proper closed algebraic subset, outside a measure-zero set, or — in the sense of O'Hara — with rationally independent distances or a non-degeneracy condition) must NOT be expressed as 「一般的な」or 「一般の」. Those Japanese words mean "general / typical / widely applicable" — a non-technical qualification — and do not carry the algebro-geometric or measure-theoretic precision of "generic." Conflation creates a logical error: "一般的な有限距離空間では P が成立する" reads as "P holds for a typical/arbitrary space" (i.e., universally), whereas the intended claim is "P holds for spaces outside a specific degenerate subfamily."
+**JP-12 — Distinguish technical "generic" from 一般的な／一般の.**
+The technical term "generic" (holds outside a proper closed subset, outside a measure-zero set, or under an explicit non-degeneracy condition) must NOT be expressed as 「一般的な」 or 「一般の」. Those Japanese words mean "general / typical / widely applicable" — a non-technical qualification — and do not carry the algebro-geometric or measure-theoretic precision of "generic." Conflation creates a logical error: 「一般的な X では P が成立する」 reads as "P holds for a typical/arbitrary X" (i.e., universally), whereas the intended claim is "P holds for X outside a specific degenerate subfamily."
 
 Correct substitutes:
 - **technical generic** → 「generic な」(recommended: preserves the term, unambiguous), or 「一般位置の」(for algebraic-geometry-style general-position conditions), or an explicit description of the non-degeneracy condition
 - **technical non-generic** → 「非 generic な」, 「退化した」(when degeneracy is the focus), or 「特殊な（対称性の高い）」(when special structure is the focus)
-- **non-technical general** → 「一般の」, 「一般的な」remain correct for "for a general [arbitrary representative of the class]"
+- **non-technical general** → 「一般の」, 「一般的な」 remain correct for "for a general [arbitrary representative of the class]"
 
-Severity: BLOCKING when the conflation appears in theorem statements, in the scope of a cited result (e.g., characterising O'Hara's theorem), or in the introduction when the distinction between the generic and degenerate case is the main point. MINOR in expository prose or narrative framing.
+Severity: BLOCKING when the conflation appears in theorem statements, in the scope of a cited result, or in the introduction when the distinction between the generic and degenerate case is the main point. MINOR in expository prose or narrative framing.
 
-**JP-13 — 分野外借用語・比喩の排除．**
-純粋数学の散文では，物理・工学・統計・機械学習に由来する借用語，および物語的・擬人的比喩を用いない．The test: would the word appear, with the same meaning and without a definition, in a published Japanese mathematics journal article? If not, replace it with the precise mathematical object or operation. Representative pairs (the rule targets the whole class, not only this list):
-- 証人（witness）→「明示例」「具体的な配置対」「〜を満たす例」
+**JP-13 — Ban vocabulary and metaphors borrowed from outside mathematics.**
+Pure-mathematics prose must not use loanwords from physics, engineering, statistics, or machine learning, nor narrative or anthropomorphic metaphors. The test: would the word appear, with the same meaning and without a definition, in a published Japanese mathematics journal article? If not, replace it with the precise mathematical object or operation. Representative pairs (the rule targets the whole class, not only this list):
+- 証人（witness）→「明示例」「具体例」「〜を満たす例」
 - 模型（model, physics sense）→「例」「構成」
 - 機構・装置・回路・エンジン・からくり・仕組み →「構成」「議論の構造」, or delete and state the mechanism directly
 - 異常・病理 →「退化した場合」「反例」
@@ -111,37 +111,38 @@ Severity: BLOCKING when the conflation appears in theorem statements, in the sco
 - 層別（する・される）→「分類」「階層」(only when the hierarchy is formally defined)
 - 帳簿・台帳（bookkeeping）→「計数」「対応」
 - 余裕（as a translation of "margin" in an estimate）→「差」, or state the inequality directly
-- 風景・地図・物語・旅・精神（"in the spirit of"）→ delete the metaphor; state the claim or the analogy precisely（e.g., 「〜と同じ精神に立つ」→「〜の有限距離空間における対応物である」）
+- 風景・地図・物語・旅・精神（"in the spirit of"）→ delete the metaphor; state the claim or the analogy precisely（e.g., 「〜と同じ精神に立つ」→「〜の対応物である」 with the correspondence made explicit）
 
 Do NOT flag established mathematical terms whose surface form coincides with everyday or physics words: 核 (kernel), 流 (flow), スペクトル, 作用素, エネルギー法 (when citing the named method), 安定性. Severity: BLOCKING in theorem statements, abstracts, and introductions; MINOR elsewhere.
 
-**JP-14 — 全角セミコロン・未翻訳英語の混在禁止．**
-和文の数学散文では全角セミコロン「；」を用いない．並列・対比は読点・句点または文の分割で表し，enumerate 項目末尾も句点で終える．また，本文で和訳語を定義した概念（例：平衡条件）を英語のまま（balanced / unbalanced）併用しない — this creates an undeclared alias (report it also as NC-3 to `math-notation-consistency`). English adjectives such as genuine, strictness must not qualify Japanese nouns bare; unpack the intended condition in Japanese（e.g., 「genuine な極」→「分子が同時に零にならない極」）. Terms with no established Japanese translation that the document itself introduces (magnitude, homometric, generic, isospectral …) are exempt. Severity: MINOR for semicolons; BLOCKING for an English alias of a defined Japanese term in a theorem statement or summary of results.
+**JP-14 — No full-width semicolons; no untranslated English for defined Japanese terms.**
+Japanese mathematical prose must not use the full-width semicolon 「；」. Express parallelism or contrast with 読点・句点 or by splitting the sentence, and end enumerate items with 句点. A concept the document defines with a Japanese term must not also be used in its English form (e.g., a defined 平衡条件 later written as balanced / unbalanced) — this creates an undeclared alias; report it also as NC-3 to `math-notation-consistency`. English adjectives such as genuine or strict must not qualify Japanese nouns bare; unpack the intended condition in Japanese（e.g., 「genuine な極」→「分子が同時に零にならない極」）. Terms the document itself introduces because no established Japanese translation exists (e.g., generic, well-posed) are exempt. Severity: MINOR for semicolons; BLOCKING for an English alias of a defined Japanese term in a theorem statement or summary of results.
 
-**JP-15 — 範疇名「閉形式」の禁止（明示式・明示計算への置換）．**
-「閉形式」(closed form) は *どの* 形かを述べない範疇名であり，指示対象の式を文書自身が明示的に与えている場合には用いない．「閉形式」と書くたびに読者は「閉」の境界（初等関数か，有理式か，有限和か）を推測させられるが，式が紙面にあるならその推測は不要である — 式番号で指すか，「明示式」と呼べばよい．The test: does the document display the formula the word points to? If yes, the category name is strictly less informative than the reference. 置換指針:
-- 式そのものを指す名詞用法（「X の閉形式」）→「X の明示式」＋式番号参照（例「magnitude の明示式 \eqref{eq:mag}」），または式そのもの・式番号のみ
-- 「同一の閉形式 X をもつ」→ 何が一致するかを明示（「同一パラメータから定まる同一の X」「明示式 \eqref{…} により同一の X」）
-- 「閉形式で確認する／計算する／一致する」という様態用法 →「明示的に計算して確認する」「直接計算により」「明示式 \eqref{…} として一致する」
-- 定理・命題・補題のタイトル中（「[X の閉形式]」）→「[X の明示式]」．`\label{...}` の内部識別子は変更しない
-誤検出除外: (a) 微分幾何・de Rham 理論の「閉形式」(closed differential form, \(d\omega=0\)) は確立した術語であり対象外（完全形式・コホモロジーが近傍に現れるのが目印）．(b) 閉形式解の存在・非存在それ自体が主題で，文書が「閉形式」の意味を形式的に定義している場合（微分 Galois 理論，Liouville 流の初等関数論など）は対象外．(c) 引用文献のタイトル・定理名に含まれる場合は原文のまま残す．Severity: BLOCKING in theorem/proposition/lemma statements and titles, abstracts, and summaries of results; MINOR elsewhere.
+**JP-15 — Ban the vague category name 閉形式 for formulas the document states explicitly.**
+「閉形式」(closed form) is a category name that does not say *which* form: each use forces the reader to guess where the boundary of "closed" lies (elementary functions? rational expressions? finite sums?). When the document displays the formula the word points to, that guess is unnecessary — point to the equation number or call it 明示式. The test: does the document display the formula the word refers to? If yes, the category name is strictly less informative than the reference. Replacement guide:
+- Noun use naming the formula（「X の閉形式」）→「X の明示式」 plus an equation reference（「X の明示式 \eqref{eq:...}」）, or the equation itself / equation number alone
+- 「同一の閉形式 X をもつ」→ state what coincides（「同一パラメータから定まる同一の X」,「明示式 \eqref{…} により同一の X」）
+- Adverbial use（「閉形式で確認する／計算する／一致する」）→「明示的に計算して確認する」「直接計算により」「明示式 \eqref{…} として一致する」
+- In theorem/proposition/lemma titles（「[X の閉形式]」）→「[X の明示式]」; do not change `\label{...}` identifiers
+
+Exemptions: (a) closed differential forms（\(d\omega=0\)）in differential geometry and de Rham theory — an established term; nearby mentions of exact forms or cohomology are the cue; (b) documents where closed-form solvability is itself the subject and 「閉形式」 is formally defined (differential Galois theory, Liouville-style elementary-function theory); (c) cited titles and theorem names — leave verbatim. Severity: BLOCKING in theorem/proposition/lemma statements and titles, abstracts, and summaries of results; MINOR elsewhere.
 
 ## Examples
 
 ```
-Before（JP-1）: したがって ν₋ は配置を区別すると考えられる。
-After:          したがって ν₋ は配置を区別する（系 2.3）。
+Before（JP-1）: したがって I は X と Y を区別すると考えられる。
+After:          したがって I は X と Y を区別する（系 2.3）。
 ```
 
 ```
-Before（JP-2）: Z_X(t) は正則行列であった。
-After:          Z_X(t) は正則行列である。
+Before（JP-2）: A(t) は正則行列であった。
+After:          A(t) は正則行列である。
 ```
 
 ```
 Before（JP-3）: ゆえに補題 2.1 の条件が満たされたことが示された。
 After:          ゆえに補題 2.1 の条件が満たされる。
-                （または，外部補題を引用した場合：「補題 2.1 により条件が満たされていることが示されている。」）
+                （または，外部結果を引用した場合：「[12] により条件が満たされていることが示されている。」）
 ```
 
 ```
@@ -150,13 +151,13 @@ After:          （削除；節の遷移は見出しで十分）
 ```
 
 ```
-Before（JP-5）: 三角不等式が成立することは明らかである。
-After:          三角不等式は max(α,β) ≤ 2 min(γ,δ) および |γ−δ| ≤ min(α,β) から従う（補題 2.2）。
+Before（JP-5）: 不等式 (4) が成立することは明らかである。
+After:          不等式 (4) は両辺を比較して直ちに従う（補題 2.2）。
 ```
 
 ```
-Before（JP-6）: 本節では S_r の性質を述べる。S_r を次で定義する。[section heading: "S_r の性質"]
-After:          （「本節では…」の行を削除）S_r を次で定義する。
+Before（JP-6）: 本節では f の性質を述べる。f を次で定義する。[section heading: "f の性質"]
+After:          （「本節では…」の行を削除）f を次で定義する。
 ```
 
 ```
@@ -165,52 +166,41 @@ After:          P ならば Q が成り立つ。
 ```
 
 ```
-Before（JP-9）: この場合，S_r が配置に依存しないとは言えない。
-After:          この場合，S_r は配置に依存する可能性がある。
-                （または確定している場合：「この場合，S_r は配置に依存する。」）
+Before（JP-9）: この場合，f が u に依存しないとは言えない。
+After:          この場合，f は u に依存する可能性がある。
+                （または確定している場合：「この場合，f は u に依存する。」）
 ```
 
 ```
-Before（JP-11）: 配置の非依存性の証明の骨子の説明を与える。
-After:           配置非依存性の証明の概略を述べる。
+Before（JP-11）: 解の一意性の証明の方針の説明を与える。
+After:           解の一意性の証明方針を述べる。
 ```
 
 ```
-Before（JP-12）: 一般的な有限距離空間では one-point property が成立する。
-                 （O'Hara の有理独立条件を満たす generic な空間に対する結果として書いた場合）
-After:           generic な有限距離空間では one-point property が成立する。
+Before（JP-12）: 一般的な行列では固有値はすべて単純である。
+                 （判別式の零点集合の外で成り立つ generic な主張として書いた場合）
+After:           generic な行列では固有値はすべて単純である。
 ```
 
 ```
-Before（JP-12）: O'Hara の意味で非一般的な（対称性の高い）族
-After:           O'Hara の意味で非 generic な（対称性の高い）族
+Before（JP-13）: この例の組が定理の証人である。
+After:          この例の組が定理の主張を満たす明示例である。
 ```
 
 ```
-Before（JP-13）: この配置対が定理の証人である。
-After:          この配置対が定理の主張を満たす明示例である。
+Before（JP-13）: 不変量 I の検出力は完全に層別される。
+After:          不変量 I が区別する対象対の全体は，定理 6.5 の条件により特徴づけられる。
 ```
 
 ```
-Before（JP-13）: ν₋ の検出力は完全に層別される。
-After:          ν₋ が区別する配置対の全体は，閾値超過多重集合により特徴づけられる（定理 6.5）。
+Before（JP-14）: 等号は unbalanced な場合に実現する；他の場合は balance が成り立つ。
+After:          等号は平衡条件を満たさない場合に実現する。他の場合は平衡条件が成り立つ。
 ```
 
 ```
-Before（JP-14）: R=1 は unbalanced 証人により実現する；他の場合は balance を強制する。
-After:          R=1 は平衡条件を満たさない組により実現する。他の場合は平衡条件が必要である。
-```
-
-```
-Before（JP-15）: \begin{proposition}[magnitude の閉形式]\label{prop:closed}
-After:          \begin{proposition}[magnitude の明示式]\label{prop:closed}
+Before（JP-15）: \begin{proposition}[母関数の閉形式]\label{prop:closed}
+After:          \begin{proposition}[母関数の明示式]\label{prop:closed}
                 （ラベルは変更しない）
-```
-
-```
-Before（JP-15）: 同一の閉形式 magnitude をもつ二配置が存在する。
-After:          同一パラメータから定まる同一の magnitude をもつ二配置が存在する。
-                （または：明示式 \eqref{eq:mag} により同一の magnitude をもつ二配置が存在する。）
 ```
 
 ```


### PR DESCRIPTION
Closes #117

## Summary

Adds three companion review skills for mathematical writing, with disjoint mandates and explicit mutual cross-references:

- **math-claim-integrity** (R-A…R-L) — structural/logical integrity: quantifier exactness, domain-of-definition guards, attribution boundary, proof/computation honesty, stale claims, theorem hierarchy, intro–body consistency, notation accuracy at introduction, define-before-use, standing assumptions, undefined relation symbols or coined terms in summary claims.
- **math-notation-consistency** (NC-1…NC-7) — notation bookkeeping: single definition site, orphaned macros, alias detection (including cross-language pairs), scope reuse, back-references after section gaps, dangling cross-references, sub/superscript conventions.
- **wabun-math-style** (JP-1…JP-15) — Japanese-language anti-patterns: epistemic hedges, tense, proof voice, connective discipline, bare 明らか, meta-discourse, は/が, ならば/とき, double negation, の-chains, generic/general conflation, borrowed vocabulary, full-width semicolons / untranslated English, vague 閉形式.

The final commit generalizes all three beyond their originating paper: field-generic examples, no project-specific symbols or collaborator/cited-author names, rule prose unified to English per AGENTS.md (Japanese retained only as quoted linguistic data), and `skills/README.md` updated.

## Validation

- `python3` frontmatter check: all three SKILL.md files parse, `name` matches directory, required keys present — OK (148/153/243 lines).
- Residue grep for originating-paper tokens (`O'Hara`, `Kamiyama`, `Z_X`, `S_r`, `magnitude ≺`, `等長型`, `Mag(` …): no matches.
- Cross-reference grep: R-J↔NC-1, R-I↔NC-3, R-L↔NC-1, JP-3↔R-C, JP-14↔NC-3 all present and mutually consistent.
- `skills/README.md` lists all three skills.
- No CI workflows in this repository; no test suite applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
