### PR TITLE
Add math-writing rationale document and design-intent capsules

### DIFF
--- a/docs/skill-rationales/math-writing.md
+++ b/docs/skill-rationales/math-writing.md
@@ -1,0 +1,276 @@
+# Design rationale: mathematical-writing skills
+
+Maintenance-only document. It is not runtime skill context and is not copied into
+installed skill directories; it exists so a maintainer or reviewer can recover why
+a rule exists without reconstructing issue history.
+
+Covers three skills:
+
+- `skills/wabun-math-style/SKILL.md`
+- `skills/math-notation-consistency/SKILL.md`
+- `skills/math-claim-integrity/SKILL.md`
+
+Original implementation: PR [#118](https://github.com/t-uda/skills/pull/118).
+Active revision issue: [#126](https://github.com/t-uda/skills/issues/126) — any
+semantic rewrite of the rules below belongs there, not here. This document
+preserves *design intent*; it must not silently weaken any target behaviour or
+drop any "Protected behaviour" clause when edited.
+
+## 1. `wabun-math-style`: implication, cases, and discourse roles
+
+### Originating failure mode
+
+AI-generated Japanese mathematical prose often flattens distinct logical and
+discourse roles — logical implication, introduction of standing assumptions,
+case selection, parameter regimes, proof progression, and comparison with prior
+work — into near-interchangeable connective words: `ならば`, `とき`, `場合`. The
+result is formally plausible Japanese whose logical structure is difficult to
+recover.
+
+### Theorem-level anti-pattern
+
+In theorem, proposition, and lemma statements, the logical antecedent and
+consequent should be explicit.
+
+Clear intended form:
+
+```text
+X を固定する。このとき、A ならば B である。
+```
+
+Here `このとき` receives the object and standing assumptions introduced before
+it, and `A ならば B` states the actual implication.
+
+Clear anti-pattern:
+
+```text
+X を固定する。A のとき B である。
+```
+
+when `A のとき` is merely substituting for the implication `A → B`. The problem
+is not that every occurrence of `とき` is forbidden — it is that theorem-level
+implication has been hidden inside a case-like phrase.
+
+### Valid theorem-level uses of `とき` and `場合`
+
+Do not flag genuine parameter regimes or cases, for example: `n が偶数の場合`,
+`t > 0 のとき`, `境界を含む場合と含まない場合`. The deciding question is whether
+the phrase names a case under discussion or silently carries the theorem's
+antecedent.
+
+### Proof context
+
+Inside proofs, `とき` and `場合` usually have stronger case-split or
+current-regime roles. Conversely, repeatedly restating an already available
+implication can make the proof indirect and tedious. Natural proof
+progression: `A より B である。` or `補題 2.1 と A から B が従う。` A
+potentially tedious progression: `A ならば B である。いま A なので B である。`
+Use `A ならば B` in a proof when the implication itself is being proved,
+quoted, or isolated as a reusable subclaim — do not require full syllogistic
+restatement at every deduction.
+
+### Expository prose
+
+In introductions and comparison prose, `とき` and `場合` often correctly
+describe a regime or relative position (`有限次元の場合`, `正則性を仮定しない
+とき`, `従来法を用いる場合`). These remain valid unless the sentence is actually
+presenting a theorem-like implication and obscures its antecedent/consequent
+structure.
+
+### Protected behaviour
+
+Future compression or generalisation must preserve the ability to distinguish
+theorem statements, proofs, and exposition. The rule must not collapse into
+either bad extreme: globally replacing every `とき`/`場合` with `ならば`, or
+allowing `A のとき B` everywhere because it is colloquially understandable.
+
+## 2. `wabun-math-style`: unnatural Japanese literal translations and AI metaphors
+
+### Originating failure mode
+
+Language models repeatedly import English mathematical or technical wording
+into Japanese through unnatural literal translation. The corresponding English
+concept may be legitimate, but the Japanese expression is often alien to
+mathematical papers, semantically vague, or metaphorical where the text should
+name a concrete object or relation. The rule targets Japanese mathematical
+usage and must not be weakened merely because the English source expression
+sounds natural.
+
+### Strong default anti-patterns
+
+The following remain strong default findings when unexplained in theorem
+statements, proofs, abstracts, or contribution summaries: `証人`, `模型` (as a
+generic translation of "model" rather than an established technical term),
+`機構`, `装置`, `回路`, `エンジン`, `からくり`, `仕組み`, `異常`, `病理`,
+`感知する`, `検出する`, `層別` (as a vague hierarchy/layering metaphor), `帳簿`,
+`台帳`, `余裕` (when substituting for a quantitative difference or strict
+inequality), `風景`, `地図`, `物語`, `旅`, `精神`. These words commonly hide the
+mathematical content instead of expressing it.
+
+### Typical repairs
+
+- `この不変量は差異を検出する` → `この不変量は指定された二つの対象を区別する`
+- `証明の機構` → identify the actual map, estimate, induction, decomposition, or
+  correspondence
+- `評価式には余裕がある` → state the relevant difference, bound, or strict
+  inequality
+- `反例の証人` → identify an explicit example, element, counterexample, or
+  object satisfying the required property
+
+### Narrow technical-term exceptions
+
+A narrow exception applies when the Japanese term is established in the
+relevant field and used with that exact technical meaning, or when the paper
+explicitly defines it as a local technical term — e.g. `模型` in model theory,
+`統計量` for a genuine statistic in probability/statistics, `検出` where
+detection is an established technical operation in that field, `層別` in an
+established technical expression (e.g. a recognised statistical procedure). Do
+not infer an exception from English usage alone.
+
+### Special handling of `統計量`
+
+`統計量` should not be banned categorically — it is valid for a genuine
+statistic. Flag it when used as a generic label for an arbitrary scalar
+quantity, invariant, score, or summary with no statistical meaning.
+
+### Protected behaviour
+
+Future maintainers must not reinterpret JP-13 as a generic ban on
+interdisciplinary concepts. Its purpose is to reject unnatural Japanese
+literal translations and decorative AI metaphors while preserving established
+Japanese technical terminology.
+
+## 3. `math-notation-consistency`: canonical definitions and live scope
+
+### Originating failure modes
+
+The skill was created to catch document-level notation degradation: a
+document-specific symbol used in a theorem or conclusion with no locatable
+definition; the same object acquiring multiple undeclared aliases across
+revisions; a symbol silently changing meaning within a live scope;
+cross-language name drift; a relation sign appearing in the abstract or
+conclusion without a definition in the body; old notation reappearing after a
+long gap with no locally recoverable meaning; dangling LaTeX references and
+orphaned macros.
+
+### Meaning of the canonical-definition rule
+
+The original strong wording around "one definition site" was intended to
+force the agent to locate a canonical meaning and detect incompatible
+redefinition — it was not intended to count every textual occurrence of a
+definition phrase. The desired operational principle:
+
+> Every nonstandard or document-specific symbol used in a load-bearing claim
+> has a locatable canonical definition. Flag missing definitions and
+> incompatible competing definitions.
+
+This preserves pressure against undefined symbols and silent redefinition
+without filling the skill with obvious exception lists.
+
+### What must remain strong
+
+Undefined document-specific symbols in load-bearing claims; incompatible
+competing definitions; undeclared aliases for the same object; cross-language
+or argument-convention drift; same-symbol reuse that creates a credible
+ambiguity within a live scope; dangling references.
+
+### Scope behaviour
+
+The live-scope concept should remain central. The audit should not treat the
+entire paper as one undifferentiated namespace, but the skill also should not
+accumulate a long catalogue of ordinary local-variable exceptions. The key
+question is whether the reader can plausibly assign two incompatible meanings
+to the same notation at the point of use.
+
+### Back-reference after a gap
+
+A long section gap is a review trigger, not a defect by itself. The
+underlying failure is that language models often revive a symbol after
+substantial intervening material without restoring enough local context for
+the reader. Flag when the old definition is no longer readily recoverable
+from the local context — do not require a mechanical back-reference solely
+because two section numbers differ by a fixed amount.
+
+### Protected behaviour
+
+A rewrite must continue to catch undefined and conflicting document-specific
+notation. It must not weaken the skill into a generic suggestion to "check
+context," nor turn it into a mechanical count of definition occurrences.
+
+## 4. `math-claim-integrity`: theorem inflation and contribution inflation
+
+### Originating failure mode
+
+Language models produce many intermediate mathematical results and tend to
+promote all of them because each consumed substantial reasoning or token
+budget. This creates papers containing many theorem-like statements and long
+contribution lists with little hierarchy. The reader then cannot determine
+which result is the main scholarly contribution, which statements are proof
+infrastructure, which claims are routine consequences, which results are
+examples/computations/reformulations, and which contribution-list items are
+merely different granularities of the same result. The skill must preserve a
+visible distinction between main results and supporting machinery.
+
+### Theorem hierarchy is functional, not merely nominal
+
+The rule is not based on a simplistic claim that every theorem is important
+and every proposition is minor. Evaluate the result's function: Does it carry
+independent scholarly significance? Is it advertised by the title, abstract,
+or introduction? Is it independently reusable or citable? Is it used solely as
+input to another main result? Is it an immediate corollary, routine
+calculation, worked example, or known-result reformulation? Does its
+environment name and presentation match that role? A result used solely as
+proof infrastructure should normally be a lemma or proposition and should not
+be presented as an independent main theorem unless a concrete independent
+significance is stated. This remains a strong paper-structure finding even
+though the mathematical statement itself may be true.
+
+### Contribution-list anti-pattern
+
+A common AI-generated contribution list treats all obtained outputs as
+parallel achievements — e.g. one main theorem, two lemmas used only in its
+proof, a direct corollary, a numerical example, and a reformulation of a known
+result, listed as five independent contributions. This is not merely verbose
+prose; it materially misrepresents the paper's scholarly hierarchy.
+
+### Required contribution mapping
+
+For every main contribution item, require an identifiable relation to: the
+corresponding formal result; the incumbent or prior baseline; the concrete new
+gain; the reason the item is independently significant; whether it duplicates
+another item at a different level of granularity. Unless independent
+significance is established, the following should not appear as parallel main
+contributions: infrastructure lemmas, routine corollaries, direct
+computational observations, worked examples, known-result reformulations,
+several proof components of one main result counted separately. Recommend
+moving such material to a proof, remark, example, auxiliary proposition, or
+omission, as appropriate.
+
+### Important exception
+
+An intermediate result may remain theorem-level when it has independent
+significance, independent reuse, or value beyond its role in the main proof.
+The skill should evaluate that role rather than demote results mechanically by
+environment name.
+
+### Protected behaviour
+
+Future edits must not reduce theorem hierarchy or contribution hierarchy to
+cosmetic naming preferences. The skill exists to prevent flat, inflated
+presentations of AI-generated results and to make the paper's genuine
+scholarly contribution legible.
+
+## 5. Relationship among the three skills
+
+Ownership boundaries to preserve:
+
+- `wabun-math-style` owns Japanese linguistic form, connective roles, and
+  unnatural Japanese translation patterns.
+- `math-notation-consistency` owns document-level symbol identity, aliases,
+  definition locality, and notation reuse.
+- `math-claim-integrity` owns claim structure, proof/evidence boundaries,
+  result hierarchy, and contribution hierarchy.
+
+A wording pattern may reveal a deeper claim defect, but a finding should state
+which layer is actually broken instead of duplicating the same rule across all
+three skills.

--- a/skills/math-claim-integrity/SKILL.md
+++ b/skills/math-claim-integrity/SKILL.md
@@ -7,6 +7,20 @@ description: Audit the structural and logical integrity of a mathematics paper �
 
 Audit a mathematics paper for structural and logical integrity defects: quantifier scope errors, missing domain-of-definition guards, conflation of analytic proofs with numerical evidence, theorem-hierarchy misclassification, stale open-problem claims, notation mislabeling at introduction, define-before-use violations, and standing-assumption drift. The skill is language-agnostic and field-agnostic: the rules apply to any area of mathematics and to papers written in any language. It does not touch prose style, inflation, or hype (use `deslop-prose`), and does not track symbol drift across sections (use `math-notation-consistency`).
 
+## Design intent
+
+This skill prevents logically weak or structurally inflated papers by
+preserving claim/evidence boundaries and a legible hierarchy between genuine
+main contributions and proof infrastructure. It targets a recurring failure
+mode where a language model promotes every intermediate result it produced —
+lemmas, routine corollaries, worked examples, known-result reformulations — to
+theorem status or an independent contribution-list entry, because each
+consumed substantial reasoning budget, leaving the reader unable to identify
+the paper's actual scholarly contribution. Maintainer note: see
+[`../../docs/skill-rationales/math-writing.md`](../../docs/skill-rationales/math-writing.md)
+for the full design rationale (maintenance-only; not required runtime
+context).
+
 ## Use when
 
 Use this skill when:

--- a/skills/math-claim-integrity/SKILL.md
+++ b/skills/math-claim-integrity/SKILL.md
@@ -17,9 +17,9 @@ lemmas, routine corollaries, worked examples, known-result reformulations — to
 theorem status or an independent contribution-list entry, because each
 consumed substantial reasoning budget, leaving the reader unable to identify
 the paper's actual scholarly contribution. Maintainer note: see
-[`../../docs/skill-rationales/math-writing.md`](../../docs/skill-rationales/math-writing.md)
-for the full design rationale (maintenance-only; not required runtime
-context).
+[`docs/skill-rationales/math-writing.md`](https://github.com/t-uda/skills/blob/main/docs/skill-rationales/math-writing.md)
+in the source repository for the full design rationale (maintenance-only; not
+required runtime context and not shipped with installed copies).
 
 ## Use when
 

--- a/skills/math-notation-consistency/SKILL.md
+++ b/skills/math-notation-consistency/SKILL.md
@@ -7,6 +7,19 @@ description: Audit a LaTeX mathematics document for notation drift — symbols u
 
 Audit a LaTeX mathematics document for internal notation consistency. The skill is field-agnostic and applies to documents in any language; it checks bookkeeping (definition sites, aliases, scopes, cross-references), not mathematical correctness or stylistic convention.
 
+## Design intent
+
+This skill prevents revision-driven notation drift: language models revising a
+document repeatedly lose track of whether a document-specific symbol still has
+a single locatable canonical definition, letting undefined, conflicting, or
+ambiguously reused notation accumulate across revisions. The "one definition
+site" wording targets locating a canonical meaning and catching incompatible
+redefinition — not counting every textual occurrence of a definition phrase.
+Maintainer note: see
+[`../../docs/skill-rationales/math-writing.md`](../../docs/skill-rationales/math-writing.md)
+for the full design rationale (maintenance-only; not required runtime
+context).
+
 ## Use when
 
 - A LaTeX math paper has been through multiple revisions and may have notation drift (same object referred to by two names in different sections)

--- a/skills/math-notation-consistency/SKILL.md
+++ b/skills/math-notation-consistency/SKILL.md
@@ -16,9 +16,9 @@ ambiguously reused notation accumulate across revisions. The "one definition
 site" wording targets locating a canonical meaning and catching incompatible
 redefinition — not counting every textual occurrence of a definition phrase.
 Maintainer note: see
-[`../../docs/skill-rationales/math-writing.md`](../../docs/skill-rationales/math-writing.md)
-for the full design rationale (maintenance-only; not required runtime
-context).
+[`docs/skill-rationales/math-writing.md`](https://github.com/t-uda/skills/blob/main/docs/skill-rationales/math-writing.md)
+in the source repository for the full design rationale (maintenance-only; not
+required runtime context and not shipped with installed copies).
 
 ## Use when
 

--- a/skills/wabun-math-style/SKILL.md
+++ b/skills/wabun-math-style/SKILL.md
@@ -16,9 +16,9 @@ words such as `ならば`/`とき`/`場合`, and separately import unnatural lit
 translations or decorative metaphors (e.g. `証人`, `機構`, `検出する`) that
 obscure the actual mathematical object, relation, or proof step. Maintainer
 note: see
-[`../../docs/skill-rationales/math-writing.md`](../../docs/skill-rationales/math-writing.md)
-for the full design rationale (maintenance-only; not required runtime
-context).
+[`docs/skill-rationales/math-writing.md`](https://github.com/t-uda/skills/blob/main/docs/skill-rationales/math-writing.md)
+in the source repository for the full design rationale (maintenance-only; not
+required runtime context and not shipped with installed copies).
 
 ## Use when
 

--- a/skills/wabun-math-style/SKILL.md
+++ b/skills/wabun-math-style/SKILL.md
@@ -7,6 +7,19 @@ description: Detect and correct Japanese-language anti-patterns in mathematical 
 
 A language-review skill for Japanese mathematics writing. It targets the class of errors that arise specifically in Japanese mathematical prose: epistemic hedges that misrepresent proved claims as uncertain, tense inconsistencies in theorem statements, voice confusion in proof steps, connectives that mark logical steps without logical warrant, bare 明らか/自明/容易に without justification, redundant meta-discourse openers, は/が particle ambiguity in theorem subjects, ならば/とき confusion in conditional hypotheses, double-negation hedging, and の-chains that obscure the main predicate. The skill is field-agnostic: the rules apply to any area of mathematics. It operates strictly at the language layer and does not evaluate mathematical correctness, quantifier scope, theorem hierarchy, or proof/computation honesty.
 
+## Design intent
+
+This skill preserves explicit logical roles (implication, standing assumption,
+case selection) in Japanese mathematical prose against a recurring failure
+mode: language models flatten these roles into near-interchangeable connective
+words such as `ならば`/`とき`/`場合`, and separately import unnatural literal
+translations or decorative metaphors (e.g. `証人`, `機構`, `検出する`) that
+obscure the actual mathematical object, relation, or proof step. Maintainer
+note: see
+[`../../docs/skill-rationales/math-writing.md`](../../docs/skill-rationales/math-writing.md)
+for the full design rationale (maintenance-only; not required runtime
+context).
+
 ## Use when
 
 - A Japanese mathematics paper or preprint (LaTeX with ltjsarticle, jarticle, or similar) needs language review


### PR DESCRIPTION
## Summary

Closes #131.

- Adds `docs/skill-rationales/math-writing.md` — a maintenance-only rationale document preserving the design intent and protected behaviours recorded in #131 for `wabun-math-style`, `math-notation-consistency`, and `math-claim-integrity`. Links the active revision issue #126 and the original implementation PR #118.
- Adds a short `## Design intent` capsule (1–3 sentences plus a maintainer link) right after the opening summary paragraph in each of:
  - `skills/wabun-math-style/SKILL.md`
  - `skills/math-notation-consistency/SKILL.md`
  - `skills/math-claim-integrity/SKILL.md`

No rule semantics were changed. No tests, automation, PR-template fields, or repository-wide rationale framework were added. No historical example catalogue was added to any `SKILL.md`.

## Validation

```
$ for f in docs/skill-rationales/math-writing.md skills/wabun-math-style/SKILL.md \
    skills/math-notation-consistency/SKILL.md skills/math-claim-integrity/SKILL.md; do
    iconv -f UTF-8 -t UTF-8 "$f" >/dev/null && echo "OK: $f" || echo "FAIL: $f"
  done
OK: docs/skill-rationales/math-writing.md
OK: skills/wabun-math-style/SKILL.md
OK: skills/math-notation-consistency/SKILL.md
OK: skills/math-claim-integrity/SKILL.md
```

Relative link target `../../docs/skill-rationales/math-writing.md` verified to resolve from all three skill directories (`ls` from each skill dir confirmed the file exists).

`git diff --stat`:

```
docs/skill-rationales/math-writing.md     | 276 ++++++++++++++++++++++++++++
skills/math-claim-integrity/SKILL.md      |  14 ++
skills/math-notation-consistency/SKILL.md |  13 ++
skills/wabun-math-style/SKILL.md          |  13 ++
4 files changed, 316 insertions(+)
```

Per-file line/word delta (`wc -l -w`, before = `origin/main`, after = this branch):

| File | Lines before → after (Δ) | Words before → after (Δ) |
|---|---|---|
| `skills/wabun-math-style/SKILL.md` | 243 → 256 (+13) | 2702 → 2774 (+72) |
| `skills/math-notation-consistency/SKILL.md` | 153 → 166 (+13) | 1786 → 1863 (+77) |
| `skills/math-claim-integrity/SKILL.md` | 148 → 162 (+14) | 1983 → 2074 (+91) |

## Test plan

- [x] `docs/skill-rationales/math-writing.md` preserves all five sections and every "Protected behaviour" clause from #131 without weakening target behaviour.
- [x] Each affected `SKILL.md` has a `## Design intent` capsule stating the failure mode (not issue history), placed right after the opening summary paragraph, with a maintainer note linking the rationale document.
- [x] UTF-8 validity confirmed for all changed/added files.
- [x] Runtime addition per file is small (13–14 lines).
- [x] No rule semantics changed; no tests/automation/PR-template/rationale-framework added; no historical example catalogue added to any `SKILL.md`.

https://claude.ai/code/session_016EpNbhDshcvbWPwBToXxXZ