### PR TITLE
deslop-prose + deslop-history: composition check and overlap compression (#134)

### DIFF
--- a/skills/deslop-history/SKILL.md
+++ b/skills/deslop-history/SKILL.md
@@ -62,6 +62,8 @@ Use these categories.
 - `historical-meta-residue` — discussion provenance, superseded alternatives, prior drafts, process notes, defensive explanations, agent-facing framing, and negative definitions that mainly answer an earlier misunderstanding instead of stating the current role directly
 - `nonessential-context` — background that may be interesting but does not change the reader's action
 
+When content could fit more than one category, classify by this precedence and assign the first match: `current-state-essential` > `operational-rationale` > `historical-meta-residue` > `nonessential-context`. A sentence that both states a current decision and narrates how it was reached is `current-state-essential`: keep the decision, drop the narration.
+
 Keep `current-state-essential`.
 Keep `operational-rationale`, but compress it and write it in present-state terms.
 Remove `historical-meta-residue` and `nonessential-context` unless the artifact type requires them.
@@ -69,30 +71,9 @@ Do not output the classification unless the user explicitly asks for a review tr
 
 ## Removal Heuristics
 
-Candidates for deletion or rewriting include:
+Recognize `historical-meta-residue` by phrasing that narrates the discussion instead of stating the current role, such as: "This was discussed in ...", "After issue discussion ...", "This supersedes ...", "We considered ...", "In review ...", "This note exists because ...", "For now" used as discussion timing rather than a real boundary, migration or backward-compatibility framing with no current operational effect, "This is not X" that mainly reacts to earlier discussion rather than preventing a likely current misuse, or internal protocol detail that exists only to coordinate drafting or review. Treat close variants ("the earlier direction", "the first pass", "the initial draft") the same way.
 
-- "This was discussed in ..."
-- "After issue discussion ..."
-- "This supersedes ..."
-- "The earlier direction ..."
-- "The first pass ..."
-- "The initial draft ..."
-- "This note exists because ..."
-- "We considered ..."
-- "In review ..."
-- "For now" when it reflects discussion timing rather than a real boundary
-- migration or backward-compatibility framing with no current operational effect
-- "This is not X" when it mainly reacts to earlier discussion rather than preventing a likely current misuse
-- internal protocol detail that exists only to coordinate drafting or review
-
-Candidates for retention include:
-
-- active constraints that still shape implementation or use
-- current interfaces, contracts, and responsibility boundaries
-- compatibility requirements that affect actual behaviour
-- open issue links that define unresolved operational boundaries
-- rationale that prevents a likely wrong implementation
-- dates, versions, or commit references when freshness or compatibility matters
+Retain phrasing that matches one of these patterns lexically but is `current-state-essential` or `operational-rationale` under the classification precedence above — most often: active constraints, current interfaces and contracts, compatibility requirements affecting actual behaviour, open issue links defining unresolved boundaries, rationale that prevents a likely wrong implementation, and dates/versions/commit references where freshness or compatibility matters.
 
 ## Rewrite Rules
 
@@ -100,11 +81,10 @@ Candidates for retention include:
 - Replace provenance with direct current-state wording.
 - Replace "This supersedes X" with "Use Y" unless readers must actively avoid X.
 - Remove defensive framing about why the artifact exists.
-- Remove agent-facing process commentary from user-facing outputs.
 - Keep caveats that affect execution, but make them operational.
 - Rewrite negative definitions into positive current-state statements when possible.
 - Keep negative framing only when it prevents a likely misuse by the intended reader.
-- Separate process from structure: describe the actual responsibility boundary, interface, or user model, not the planning discussion that produced it.
+- Separate process from structure: remove agent-facing process commentary and describe the actual responsibility boundary, interface, or user model, not the planning discussion that produced it.
 - Replace internal coordination protocols with reader-facing abstractions unless the reader must execute the protocol.
 - Preserve links only when they define current authority, unresolved boundaries, or required follow-up.
 - Do not introduce new decisions, broaden scope, or erase active constraints.
@@ -131,6 +111,16 @@ Before: The 12-tier scoring protocol and 9 failure-mode taxonomy are used to syn
 After: The review uses a structured evaluation framework to identify common failure modes.
 ```
 
+```text
+Given (do not remove): This design supersedes the June proposal per ADR-014; migrate before v3.2 using the compatibility shim described in ADR-014 §4.
+Unchanged — this is a governance/decision record; the superseded-alternative reference and the compatibility requirement are both required content, not residue.
+```
+
+```text
+Given: The plan proposes either a queue-based or a polling-based retry mechanism; the team has not yet chosen between them.
+Not owned by this skill — the design question is still open. Use `metaplan` or the project's decision process first; `deslop-history` applies only after the choice converges.
+```
+
 ## Output
 
 If the user asks to edit a file, apply the cleaned artifact directly. If the user asks for review or cleanup text only, return the cleaned artifact without an audit log.
@@ -152,12 +142,10 @@ When editing repository files:
 Before finishing, verify:
 
 - the target reader can see the current decision, contract, or instruction set without reading issue history
-- remaining historical text changes present action or is required by the artifact type
-- discussion provenance, superseded alternatives, and prior-draft commentary are absent unless required by the artifact type
+- no discussion provenance, superseded alternatives, prior-draft commentary, or internal coordination-protocol detail remains unless the artifact type requires it, and any retained historical text still changes the reader's action
 - deleting removed text cannot cause likely misimplementation
-- the artifact reads as if written directly in final form
 - open issue references remain only when operationally useful
-- internal review or coordination protocol details are either removed or rewritten for the intended reader
+- classification precedence was applied consistently: no `current-state-essential` or `operational-rationale` content was misclassified and removed as residue
 
 ## Relationship to Other Skills
 

--- a/skills/deslop-prose/SKILL.md
+++ b/skills/deslop-prose/SKILL.md
@@ -26,6 +26,9 @@ Do not use this skill for:
 - source-of-truth auditing, factual verification, or citation checking
 - legal or policy text where rhetorical softening could change meaning
 - drafts that still need architectural or substantive decisions
+- quantifier scope, theorem/lemma/proposition hierarchy, or claim-level mathematical relations — this is logical content, not rhetorical inflation; use `math-claim-integrity`
+- Japanese-language phrasing anti-patterns — use `wabun-math-style`
+- judging whether a research direction or connection is worth pursuing — use `research-significance`
 
 Use `deslop-history` when the artifact leaks process history, superseded alternatives, or agent-facing framing.
 
@@ -75,6 +78,7 @@ Ask only when rewriting could blur a technical term, scope boundary, or required
 - Rewrite long ad hoc hyphenated compounds as ordinary noun phrases unless the compound is standard.
 - Keep negative framing only when it prevents a likely misuse.
 - Do not turn precise prose into smooth but lower-density prose.
+- Do not change quantifier scope, hypothesis strength, or theorem/lemma/proposition naming and hierarchy while tightening a sentence — that is a logical-content edit, not a style edit.
 
 Minimal examples:
 
@@ -86,6 +90,16 @@ After: This framework identifies the practical conditions under which the method
 ```text
 Before: We systematically and rigorously analyse the method across efficiency, scalability, robustness, interpretability, and applicability.
 After: We evaluate runtime and robustness on the reported benchmarks.
+```
+
+```text
+Must not flag: The estimator is asymptotically efficient and consistent under standard regularity conditions.
+Unchanged — "asymptotically efficient," "consistent," and "regularity conditions" are established statistical terms, not inflation, despite the sentence's density.
+```
+
+```text
+Owned by a neighbouring skill, not this one: We prove three new theorems, but one is used only to establish the other two.
+This is a theorem-hierarchy defect (independent results conflated with proof infrastructure), not prose inflation — use `math-claim-integrity` (rule R-F), not `deslop-prose`.
 ```
 
 ## Output
@@ -113,9 +127,13 @@ Before finishing, verify:
 - technical meaning, qualifications, and terminology remain intact
 - the prose sounds more direct, not more impressive
 - `deslop-history` would not be the more appropriate skill
+- no quantifier, hypothesis, or theorem-hierarchy content changed in the course of tightening a sentence
 
 ## Relationship to Other Skills
 
 - Use `deslop-history` when the main problem is discussion provenance, prior-draft residue, or process framing.
 - Use `sot-integrity` when authority, factual grounding, or trust scope must be audited.
 - Use `textlint-cli` for deterministic lint checks, not context-sensitive prose judgment.
+- Use `math-claim-integrity` for quantifier scope, theorem/proposition hierarchy, proof/computation honesty, or other logical-structural defects; this skill never edits claim-level mathematical content.
+- Use `wabun-math-style` for Japanese-language anti-patterns (particle misuse, unnatural literal translation, epistemic hedges); this skill is language-agnostic and does not target Japanese-specific phrasing.
+- Use `research-significance` to assess whether a research direction or connection has scholarly value; this skill only cleans prose after that judgment is made.


### PR DESCRIPTION
Closes #134. Child of #126 (parent audit). Scope of this PR: `skills/deslop-prose/SKILL.md` and `skills/deslop-history/SKILL.md` only.

## Method

Semantic validation before compression, per #126: for each skill, verified failure mechanism and anti-pattern coverage, checked boundary accuracy against `wabun-math-style`, `math-claim-integrity`, `math-notation-consistency`, and `research-significance`, then compressed overlapping enumeration where the parent doctrine (2026-07 metaplan re-evaluation) says long "look-for" lists are capability-redundant for frontier reviewers — trigger, output contract, authority binding, and inter-skill boundaries are the durable value and were never compressed.

## Rule matrix

### `deslop-prose`

| Rule / group | Classification | Stated scope | Failure mechanism if violated | Anti-pattern targeted | Bounded exceptions | Overlap w/ neighbour |
|---|---|---|---|---|---|---|
| `hype-inflation`, `framework-inflation`, `methodological-theatre`, `vague-significance`, `formulaic-symmetry` | heuristic | any prose sentence | reader cannot recover the concrete claim from decorative wording | LLM tendency to inflate importance without support | none needed — always contextual | `research-significance` owns *whether* a claim is actually significant; this skill only fixes vague wording around a claim already made |
| `enumeration-inflation`, `hyphen-chain-pseudo-terms` | heuristic | lists / compounds | implies coverage or precision not actually present | decorative structure standing in for content | standard compounds/lists are exempt | none |
| `generic-metadiscourse`, `defensive-negative-framing` | convention | scaffolding phrases | displaces content with throat-clearing | AI-shaped filler | keep negative framing when it prevents a likely misuse (bounded exception, stated) | none |
| `unstable-terminology` | convention | terminology choice | obscures a standard concept behind a novel paraphrase | freshness-seeking paraphrase | established/precise terms are preserved, not paraphrased | overlaps `wabun-math-style` JP-13 for the JP-specific case of the same failure (borrowed vocabulary standing in for a precise term) |
| `claim-evidence-mismatch` | heuristic, bounded to calibration only | certainty/breadth/importance vs. text-local evidence | claim reads stronger than the support stated nearby | LLM confidence inflation | explicitly **not** factual verification or citation checking (scope line, unchanged) — this rule only compares a claim to evidence *already stated in the artifact*, it never adjudicates truth | `sot-integrity` (factual grounding / trust scope), `research-significance` (whether a result is a genuine contribution) |
| New: quantifier/hierarchy non-interference rule (added this PR) | invariant (boundary) | any sentence being tightened | rewriting for concision silently drops a quantifier, hypothesis, or theorem/lemma/proposition distinction | prose-compression collapsing a logical distinction | none — hard boundary | `math-claim-integrity` R-A (quantifier exactness), R-F (theorem hierarchy) own the correctness of this content |

Verdict/severity precedence: **not applicable**. `deslop-prose` has no verdict or severity system (it edits directly; findings are not scored or ranked), so there was no implicit precedence to make deterministic.

### `deslop-history`

| Rule / group | Classification | Stated scope | Failure mechanism if violated | Anti-pattern targeted | Bounded exceptions | Overlap w/ neighbour |
|---|---|---|---|---|---|---|
| Classification categories (`current-state-essential`, `operational-rationale`, `historical-meta-residue`, `nonessential-context`) | policy (repository/artifact-type norm for what belongs in final-form output) | any final user-visible artifact derived from discussion | reader must reconstruct current state from discussion archaeology | AI/agent tendency to leave provenance narration in final artifacts | artifact types that require history (changelogs, postmortems, ADRs, audit trails) are out of scope entirely (`Do not use`) | `sot-integrity` (authority/trust, not residue), `metaplan` (open design questions, not converged decisions) |
| Classification precedence (**added this PR**) | policy | applies when a paragraph could fit >1 category | without a fixed order, a sentence carrying both a decision and its provenance narration could be misclassified as residue and deleted, losing the decision | ambiguous dual-purpose sentences | first-match order: `current-state-essential` > `operational-rationale` > `historical-meta-residue` > `nonessential-context` (mirrors the #128 `research-significance` deterministic decision-order fix) | none |
| Removal heuristics (lexical residue markers) | heuristic | phrasing recognition only, always checked against classification before deletion | over-eager pattern match deletes required content that merely resembles a residue phrase | narration-shaped sentences masking a live decision | retention list cross-referenced to policy categories (compatibility, active constraints, dated/versioned references) | none |
| Rewrite rules (present-tense conversion, supersession→"Use Y", drop defensive framing, etc.) | convention | applies only to content already classified for retention | retained content still reads as meeting-minutes prose instead of direct instruction | provenance-shaped phrasing surviving into "final" prose | negative framing kept only when it prevents a likely misuse (bounded exception, stated); links kept only when they define current authority/boundaries/follow-up | none |
| "Do not remove" carve-outs (compatibility/migration/deprecation notes; misimplementation-preventing rationale) | invariant (removing changes actual correctness of use, not just style) | any artifact | reader silently loses a constraint needed to use the artifact correctly | over-aggressive residue removal | none — always retained if it affects current behaviour | none |

Verdict/severity precedence: the only place severity was implicit was the classification step above (no rule for resolving a paragraph matching two categories); this PR adds the deterministic first-match order, following the same pattern as the #128 fix to `research-significance`.

## Semantic changes vs. compression only

**Semantic (behavioural) changes:**
- `deslop-prose`: added a hard boundary rule (Do-not-use + Rewrite Rule + Quality Check line) that prose tightening must never alter quantifier scope, hypothesis strength, or theorem/lemma/proposition hierarchy — closes a real gap where the skill's own "tighten claims" instruction could have licensed dropping a logical distinction that belongs to `math-claim-integrity`.
- `deslop-prose`: added explicit two-way boundary statements to `wabun-math-style`, `math-claim-integrity`, and `research-significance` (previously only `deslop-history`, `sot-integrity`, `textlint-cli` were listed, even though all three math skills already pointed back at `deslop-prose`).
- `deslop-history`: added deterministic classification precedence (first-match order) for paragraphs that could fit more than one category — previously undefined, so two reviewers/agents could classify the same ambiguous sentence differently and one could delete required content.
- Both skills: added one must-not-flag example, one true-defect example, and one neighbouring-skill-owned example each (deslop-prose already had one true-defect example; deslop-history already had one — both gained the other two required cases).

**Compression only (no behavioural change):**
- `deslop-history` "Removal Heuristics": collapsed two 6–13-item bullet lists (candidates for deletion / candidates for retention) that mostly restated the four classification categories into two cross-referencing paragraphs. Same trigger phrases retained (including two that had been dropped in an earlier compression pass and were restored: "In review ..." and "migration or backward-compatibility framing with no current operational effect").
- `deslop-history` Rewrite Rules: merged two bullets that said the same thing from two angles ("remove agent-facing process commentary" + "separate process from structure") into one.
- `deslop-history` Quality Check: 7 bullets → 5, merging bullets that restated Removal Heuristics / Rewrite Rules content already covered elsewhere, and folding the terminal "reads as final form" check (a restatement of the skill's opening sentence) into the surviving checks.

`deslop-prose` needed only the boundary/example additions above — per #126's framing as "a comparatively compact reference implementation," the verification found no overlap to compress and no existing rule that needed narrowing, downgrading, or removal. Its `claim-evidence-mismatch` rule already correctly excludes factual verification (Do-not-use bullet, unchanged), its Rewrite Rules already preserve established technical terms (unchanged), and its Target Patterns already avoid flattening technical distinctions by construction (the rules operate on rhetorical wrapping, not on the underlying claim). Minimal/no change would have been a valid outcome for this file; the change actually made is a real (if narrow) gap closure, not padding.

## Validation

- `iconv -f UTF-8 -t UTF-8 <file> >/dev/null` — both files: OK
- `wc -l -w -c` before (origin/main) vs. after:

| File | Before (lines/words/chars) | After (lines/words/chars) | Approx. tokens before → after* |
|---|---|---|---|
| `skills/deslop-prose/SKILL.md` | 121 / 821 / 5793 | 139 / 1051 / 7611 | ~1070 → ~1370 |
| `skills/deslop-history/SKILL.md` | 167 / 1166 / 8200 | 155 / 1290 / 9321 | ~1520 → ~1680 |

\* approx. tokens ≈ words × 1.3, a rough heuristic, not a tokenizer count.

`deslop-history` line count dropped (167→155) from the enumeration compression despite the net word count rising, because the two new required example blocks (must-not-flag, neighbouring-skill-owned) add more words than the list-merging saved. The compression and the additions are reported separately above so this isn't read as "compression that grew the file" — it's real content added on top of real compression.

- `git diff --stat`: 2 files changed, 36 insertions(+), 30 deletions(-) (pre-final-fix numbers; see current diff on this PR for the exact final count)
- Boundary grep: every skill named in either file's "Relationship to Other Skills" / "Do not use" sections (`wabun-math-style`, `math-claim-integrity`, `math-notation-consistency`, `research-significance`, `sot-integrity`, `metaplan`, `handoff-prompt`, `textlint-cli`, `deslop-prose`, `deslop-history`) resolves to an existing directory under `skills/` in this repo.

## Acceptance criteria checklist

- [x] `deslop-prose` and `deslop-history` preserve technical meaning, required rationale, attribution, and audit history.
- [x] Repetition reduced only after the intended anti-pattern and behavioural effect were documented (see rule matrix).
- [x] Boundary statements consistent with the current skill set (verified against the current `wabun-math-style`, `math-claim-integrity`, `math-notation-consistency`, `research-significance` files in this repo).
- [x] Files are valid UTF-8 and render as plain Markdown (no non-ASCII structural characters beyond the pre-existing em dash/section-sign usage already in the files).
- [x] Every revised skill includes at least one must-not-flag example, one true-defect example, and one neighbouring-skill-owned example.
- [x] Any implicit severity/verdict precedence made deterministic (`deslop-history` classification; `deslop-prose` has no such system, confirmed N/A above).
