### PR TITLE
math-notation-consistency + math-claim-integrity: canonical-definition predicate and contribution hierarchy

### DIFF
--- a/skills/math-claim-integrity/SKILL.md
+++ b/skills/math-claim-integrity/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: math-claim-integrity
-description: Audit the structural and logical integrity of a mathematics paper — quantifier scope, domain-of-definition guards, proof/computation honesty, theorem hierarchy, contribution-list discipline (mapping every claimed contribution to its formal result, prior baseline, concrete gain, and independent significance), stale claims, notation accuracy at introduction, standing assumptions, and undefined relation symbols or coined terms in summary prose — without touching prose style or inflation patterns.
+description: Audit the structural and logical integrity of a mathematics paper — quantifier scope, domain-of-definition guards, proof/computation honesty, theorem hierarchy, contribution-list discipline (mapping every claimed contribution to its formal result, prior baseline, concrete gain, and independent significance), stale claims, notation accuracy at introduction, standing assumptions, and undefined relation symbols or coined terms in summary prose — without touching prose style or rhetorical prose inflation (structural inflation of contribution lists and result hierarchy is in scope).
 ---
 
 # Math Claim Integrity
 
-Audit a mathematics paper for structural and logical integrity defects: quantifier scope errors, missing domain-of-definition guards, conflation of analytic proofs with numerical evidence, theorem-hierarchy misclassification, stale open-problem claims, notation mislabeling at introduction, define-before-use violations, and standing-assumption drift. The skill is language-agnostic and field-agnostic: the rules apply to any area of mathematics and to papers written in any language. It does not touch prose style, inflation, or hype (use `deslop-prose`), and does not track symbol drift across sections (use `math-notation-consistency`).
+Audit a mathematics paper for structural and logical integrity defects: quantifier scope errors, missing domain-of-definition guards, conflation of analytic proofs with numerical evidence, theorem-hierarchy misclassification, stale open-problem claims, notation mislabeling at introduction, define-before-use violations, and standing-assumption drift. The skill is language-agnostic and field-agnostic: the rules apply to any area of mathematics and to papers written in any language. It does not touch prose style or rhetorical inflation and hype at the sentence level (use `deslop-prose`) — structural inflation of the contribution list or result hierarchy is in scope here (R-F, R-M) — and does not track symbol drift across sections (use `math-notation-consistency`).
 
 ## Design intent
 
@@ -37,7 +37,7 @@ Use this skill when:
 ## Do not use
 
 Do not use this skill for:
-- Prose inflation, hype, or AI-generated decoration → use `deslop-prose`
+- Sentence-level prose inflation, hype, or AI-generated decoration → use `deslop-prose` (but structural contribution/hierarchy inflation belongs here: R-F, R-M)
 - Symbol-table drift across sections → use `math-notation-consistency`
 - Japanese-specific language anti-patterns → use `wabun-math-style`
 - Discussion-history artifacts in planning docs → use `deslop-history`
@@ -203,7 +203,7 @@ When the user explicitly asks to apply fixes: edit the LaTeX source in-place and
 
 Before finishing, verify:
 - Every finding has a rule tag, classification, severity, and location
-- No finding overlaps with deslop-prose territory (prose inflation/hype)
+- No finding overlaps with deslop-prose territory (sentence-level prose inflation/hype); structural contribution/hierarchy inflation findings are correctly tagged R-F/R-M here
 - No finding reports a symbol-table issue that belongs to math-notation-consistency
 - R-H findings default to ADVISORY and only escalate to MINOR under its stated condition (circularity, use-before-definition, or a concrete readability failure) — never to BLOCKING
 - R-F and R-M findings identify the actual scholarly gain and hierarchy the paper misrepresents, not merely the environment label used

--- a/skills/math-claim-integrity/SKILL.md
+++ b/skills/math-claim-integrity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: math-claim-integrity
-description: Audit the structural and logical integrity of a mathematics paper — quantifier scope, domain-of-definition guards, proof/computation honesty, theorem hierarchy, stale claims, notation accuracy at introduction, standing assumptions, and undefined relation symbols or coined terms in summary prose — without touching prose style or inflation patterns.
+description: Audit the structural and logical integrity of a mathematics paper — quantifier scope, domain-of-definition guards, proof/computation honesty, theorem hierarchy, contribution-list discipline (mapping every claimed contribution to its formal result, prior baseline, concrete gain, and independent significance), stale claims, notation accuracy at introduction, standing assumptions, and undefined relation symbols or coined terms in summary prose — without touching prose style or inflation patterns.
 ---
 
 # Math Claim Integrity
@@ -26,6 +26,7 @@ required runtime context and not shipped with installed copies).
 Use this skill when:
 - A math paper draft needs pre-submission structural review
 - A theorem was reorganized and surrounding text may not reflect the new hierarchy
+- A §1 contribution list enumerates lemmas, routine corollaries, worked examples, or known-result reformulations as if they were parallel main results
 - A quantifier scope error (for-all vs exists, iff vs implies, general vs special-case) is suspected
 - The introduction or abstract may over-claim or misstate what the theorems actually prove
 - A proof section may be conflating analytic argument with numerical/computational evidence
@@ -51,48 +52,53 @@ Gather or infer these before starting:
 
 ## Procedure
 
-1. Read the abstract and introduction. List all informal theorem descriptions.
+1. Read the abstract and introduction. List all informal theorem descriptions and every contribution-list item.
 2. Locate every theorem-level environment (theorem, proposition, lemma, corollary) in the body.
-3. Apply rules R-A through R-L in sequence; record findings.
+3. Apply rules R-A through R-M in sequence; record findings.
 4. Produce a structured finding report.
 
 ## Rules
 
-**R-A — Quantifier exactness.**
+Each rule is tagged with a classification that sets a default severity: **invariant** — a violation makes the claim logically, structurally, or operationally wrong — defaults to BLOCKING; **convention** — a strong scholarly norm with bounded exceptions — defaults to MINOR, escalating to BLOCKING when the violation obscures logical structure, contribution hierarchy, or the reader's ability to identify the paper's main result; **heuristic** — a review trigger requiring contextual judgement — defaults to ADVISORY, escalating per its own stated condition. A rule's own text overrides this default where it states a severity explicitly. When a defect triggers more than one rule (e.g., an inflated theorem that is also miscounted in the contribution list), report each tag; the defect's severity for gating purposes is the maximum across triggered findings (BLOCKING > MINOR > ADVISORY > NOTE).
+
+**R-A — Quantifier exactness.** *(invariant)*
 Every claim must be stated at exactly the quantifier strength the proof establishes. Flag: "iff" when only one implication is proved; "for all t" when the proof only establishes "for sufficiently small t" or "for fixed t"; "for any input" when the result depends on a specific instance; a general formula when only a special case was derived. The quantifier structure of the statement must match the quantifier structure of the proof.
 
-**R-B — Domain-of-definition guard.**
+**R-B — Domain-of-definition guard.** *(invariant)*
 Any quantity defined via a potentially-failing operation (matrix inverse, division, limit, logarithm) must: (a) name its failure locus at the point of definition, and (b) have every subsequent universal claim over that quantity guarded by the same condition. Example: a quantity defined via the inverse of a parameter-dependent matrix A(t) must state that it is defined only where A(t) is invertible; every "for all t" claim about it must be guarded by "for all t where A(t) is invertible" or equivalent.
 
-**R-C — Attribution boundary.**
+**R-C — Attribution boundary.** *(convention)*
 Each theorem/proposition must be unambiguously classifiable as: (i) cited verbatim, (ii) restated/repackaged from a citation, or (iii) original to this paper. Infrastructure from cited works (constructions, prior existence results) must not be presented as the paper's own novel contribution. Conversely, genuinely original results must carry an explicit claim of novelty or must not be attributed to prior work by passive or vague phrasing. For the voice mechanics of attribution in Japanese (passive 〜が示されている vs active 〜を示す), cross-reference `wabun-math-style` rule JP-3. When the `citation_boundary` input is not supplied, all R-C findings are automatically severity NOTE ("unverifiable attribution") rather than BLOCKING or MINOR — flag the location but do not assert novelty or citedness without the boundary information.
 
-**R-D — Proof/computation honesty.**
+**R-D — Proof/computation honesty.** *(invariant)*
 Analytic/algebraic proofs and numerical/computational verifications must be strictly separated. Rules: every decimal value must be labeled as approximate or as a convenience form of an exact quantity; a load-bearing numerical claim must either have a closed-form analytic companion OR an explicit statement that the result is a certified numerical result (interval arithmetic, exact-arithmetic computation, rigorous exhaustive finite case enumeration with exact decision) with a statement of why a closed form is unavailable; grid-search or script output may be labeled as motivation or corroboration but not as a proof step.
 
-**R-E — Stale-claim elimination.**
+**R-E — Stale-claim elimination.** *(invariant)*
 Scan for claims labeled open, unresolved, conjectural, or under investigation. For each, check whether the paper itself contains a theorem that resolves the claim. A claim labeled "open" that is resolved by a theorem proved elsewhere in the same document is a hard error. A condition listed as an assumption in a theorem that the paper later proves is universally satisfied should be flagged for the author to confirm removal (MINOR severity), as authors sometimes intentionally retain explicit hypotheses for modularity or citability.
 
-**R-F — Theorem hierarchy.**
-If a result is proved solely as input to another theorem, it should be labeled Lemma or Proposition, not Theorem, and should not be enumerated independently in the §1 contribution list. If the introduction lists "three main results" and one of them is only used in the proof of another, flag the hierarchy. Conversely, the paper's central result — the one the title and abstract advertise — must appear as a named Theorem in the body, not only as a corollary of a more general statement introduced without emphasis.
+**R-F — Theorem hierarchy (functional, not nominal).** *(convention)*
+Evaluate each theorem-level result by function, not by environment label: Does it carry independent scholarly significance? Is it advertised as a main result by the title, abstract, or introduction? Is it independently reusable or citable on its own? Or is it used solely as input to another result (proof infrastructure), an immediate corollary, a routine calculation, a worked example, or a reformulation of a known result? A result used solely as proof infrastructure should normally be labeled Lemma or Proposition, not Theorem, and should not be enumerated independently in the §1 contribution list. Conversely, the paper's central result — the one the title and abstract advertise — must appear as a named Theorem in the body, not only as an unemphasized corollary of a more general statement. An intermediate result may legitimately remain theorem-level when it has independent significance, reuse, or value beyond its role in the main proof — evaluate the role, never demote mechanically by environment name alone. Severity: escalates to BLOCKING when naming/presentation flattens the actual result hierarchy enough that a reader cannot identify the paper's genuine main result, even though every individual statement is mathematically true.
 
-**R-G — Introduction–body consistency.**
+**R-G — Introduction–body consistency.** *(invariant)*
 Every informal theorem description in §1 (introduction, contributions list) must match the actual formal statement in the body. Check: quantifier direction, domain of validity, what is assumed vs. what is concluded, and what is credited to prior work vs. original. Discrepancies are most often in the introduction; fix there. Note: §1 descriptions may be informal paraphrases but must not be strictly stronger or weaker than the formal statement.
 
-**R-H — Worked example placement (advisory).**
-When the paper's proof strategy is "construct an explicit family, then abstract to a general theorem," the worked example should appear before the general theorem so readers can verify the mechanism concretely. Flag only if a worked example is referenced in the proof before it is introduced, or if the general theorem is cited in the example section in a circular way. This is an advisory finding, not a blocking error.
+**R-H — Worked example placement.** *(heuristic, advisory by default)*
+When the paper's proof strategy is "construct an explicit family, then abstract to a general theorem," the worked example should appear before the general theorem so readers can verify the mechanism concretely. Flag only if a worked example is referenced in the proof before it is introduced, or if the general theorem is cited in the example section in a circular way. Stays ADVISORY unless the placement causes a circular reference, a use-before-definition problem, or a concrete readability failure, in which case it escalates to MINOR.
 
-**R-I — Notation conceptual accuracy at introduction.**
+**R-I — Notation conceptual accuracy at introduction.** *(invariant)*
 When a symbol is introduced, its name, LaTeX macro, and description must match its mathematical role. A symbol described as "an invariant" that in fact depends on a varying parameter or an auxiliary choice (a basis, an ordering, an embedding) is a mislabeling. A macro whose name suggests a standard operator but denotes a nonstandard variant is confusing. Flag at the point of introduction, not later uses. Later-use consistency across sections is out of scope for this skill.
 
-**R-J — Define before use.**
+**R-J — Define before use.** *(invariant)*
 Every symbol appearing in a theorem statement, proof step, or displayed formula must have a formal definition or explicit introduction earlier in the document (not in a later remark or footnote). Check that every LaTeX macro used in theorem environments is either a standard math symbol or explicitly defined in the preamble or body before its first theorem-context use. Cross-section symbol bookkeeping (single definition site, back-references after gaps) is handled by `math-notation-consistency`. R-J owns completeness of theorem statements; `math-notation-consistency` owns cross-section consistency.
 
-**R-K — Standing assumption inheritance.**
+**R-K — Standing assumption inheritance.** *(invariant)*
 When a section or theorem relies on standing assumptions declared earlier (e.g., "throughout this section, X is a compact metric space"), every theorem in that section must either inherit those assumptions explicitly or state explicitly that it holds without them. After a structural revision (reordering sections, splitting a theorem), check that standing assumptions have not been silently dropped or silently over-applied. Flag any theorem whose hypothesis list differs from the standing assumptions without explanation.
 
-**R-L — No undefined relation symbols or coined terms in claims.**
+**R-L — No undefined relation symbols or coined terms in claims.** *(invariant)*
 Every relation symbol (≺, ⊏, ⋖, an arrow used as an ordering, or any ad hoc comparative notation) and every coined comparative term ("strictly finer/coarser than", "detection power", or an equivalent coinage in any language) that appears in the abstract, introduction, or conclusion must either (a) have a formal definition in the body before (or explicitly referenced at) the point of use, or (b) be replaced by the explicit logical statement it abbreviates. The standard unpacking of "invariant I₁ is strictly coarser than I₂" is: every pair distinguished by I₁ is distinguished by I₂, and there exists a pair on which I₁ agrees while I₂ differs — state both halves with references to the theorems that prove them. An undefined ≺ in a summary section is BLOCKING even when the intended meaning is guessable, because the reader cannot verify the claim against a definition. Division of labour: `math-notation-consistency` NC-1 owns the bookkeeping of definition sites; R-L owns the requirement that abstract/intro/conclusion claims be expressible entirely in defined terms.
+
+**R-M — Contribution-list mapping discipline.** *(convention; primary requirement)*
+Every item in a §1 contribution list must map to: (a) the formal result it corresponds to; (b) the incumbent or prior baseline; (c) the concrete new gain over that baseline; (d) why the item is independently significant rather than merely supporting another listed item; (e) whether it duplicates another listed item at a different level of granularity. Unless independent significance is established, the following must not appear as parallel main contributions: infrastructure lemmas, routine corollaries, direct computational observations, worked examples, known-result reformulations, or several proof components of one result counted separately. Repair: move such material into a proof, remark, example, or auxiliary proposition, or omit it from the list. Escalates to BLOCKING when the abstract or introduction materially misrepresents the paper's main scholarly contribution, even though every individual statement is mathematically true. R-F and R-M often co-fire on the same underlying inflation — R-F concerns the theorem-environment label in the body, R-M concerns whether the §1 list conflates that result with genuine main contributions; report both tags rather than treating them as duplicates.
 
 ## Examples
 
@@ -112,6 +118,53 @@ R-F — Before: [In §1 contributions list] Theorem A, Theorem B, Theorem C are 
               [In body] Theorem C is used only in the proof of Theorem B.
       After:  [In §1] Theorem B (main result) is proved, using Proposition C as
               infrastructure.
+```
+
+```
+R-F (must not flag — legitimately theorem-level intermediate result):
+[In body] Theorem 3.2 is proved as a step toward the paper's main Theorem 5.1, but
+Theorem 3.2 also settles a special case that was independently open in prior work
+and is cited on its own by a later paper in the same field.
+Finding: none — Theorem 3.2 carries independent scholarly significance (it resolves
+         a previously open special case) beyond its role as infrastructure for
+         Theorem 5.1, so theorem-level presentation is warranted; do not demote it
+         to Proposition merely because it is also used in another proof.
+```
+
+```
+R-M (contribution list double-counting proof infrastructure):
+[§1] "Our contributions: (1) Theorem A, the main classification result; (2) Lemma B,
+used in the proof of Theorem A; (3) Corollary C, an immediate consequence of Theorem
+A; (4) a numerical illustration of Theorem A on a sample instance."
+Finding (MINOR): items (2)-(4) are proof infrastructure, a routine corollary, and a
+         worked example of item (1), not independent contributions at the same
+         granularity. Demote to remarks/examples inside the discussion of Theorem A,
+         leaving one main-contribution item.
+```
+
+```
+R-M (must not flag — correct contribution list):
+[§1] "Our main contribution is Theorem A, which improves the prior bound of O(n²)
+(Smith 2019) to O(n log n). The proof uses a new decomposition lemma (Lemma B,
+§3), stated separately because it applies beyond this paper to related sieving
+problems." Lemma B's independent applicability is stated and used in a later
+worked application in the same paper.
+Finding: none — one clearly identified main result with its baseline and gain (a),
+         (b), (c); Lemma B is presented as infrastructure but with a stated,
+         demonstrated independent significance (d), not as a parallel contribution.
+```
+
+```
+R-M + R-F (true statements, misrepresented hierarchy — BLOCKING):
+[§1] "We make three equally important contributions: a new invariant (Theorem 1), a
+computation of the invariant for the trefoil knot (Theorem 2), and a restatement of
+the invariant's known additivity property in our notation (Theorem 3)." Every
+statement in Theorems 1-3 is mathematically correct.
+Finding (BLOCKING, R-F + R-M): Theorem 2 is a worked example and Theorem 3 is a
+         known-result reformulation; presenting all three as equally weighted
+         "theorems" and "contributions" misrepresents which result is the paper's
+         actual scholarly contribution, even though nothing stated is false. Demote
+         Theorems 2-3 to Example/Remark and rewrite §1 around the single main result.
 ```
 
 ```
@@ -138,8 +191,8 @@ R-L — Before: The invariants are ordered I₁ ≺ I₂ ≺ I₃. (≺ never de
 ## Output
 
 Default: review-only. Produce a structured finding report listing:
-- Rule tag (R-A through R-L)
-- Severity: BLOCKING (logical/structural error) / MINOR (advisory) / NOTE (suggestion)
+- Rule tag (R-A through R-M)
+- Classification (invariant / convention / heuristic — see Rules) and Severity: BLOCKING / MINOR / ADVISORY / NOTE, following the default-severity mapping above unless the rule states otherwise
 - Location: section heading, theorem label, or equation reference
 - One-sentence description of the violation
 - A concrete rewrite suggestion
@@ -149,10 +202,13 @@ When the user explicitly asks to apply fixes: edit the LaTeX source in-place and
 ## Quality Check
 
 Before finishing, verify:
-- Every finding has a rule tag, severity, and location
+- Every finding has a rule tag, classification, severity, and location
 - No finding overlaps with deslop-prose territory (prose inflation/hype)
 - No finding reports a symbol-table issue that belongs to math-notation-consistency
-- Advisory findings (R-H) are clearly marked MINOR, not BLOCKING
+- R-H findings default to ADVISORY and only escalate to MINOR under its stated condition (circularity, use-before-definition, or a concrete readability failure) — never to BLOCKING
+- R-F and R-M findings identify the actual scholarly gain and hierarchy the paper misrepresents, not merely the environment label used
+- R-M findings are not raised merely because a contribution list is long; they require an item that fails the (a)-(e) mapping or duplicates another item's granularity
+- A paper is not penalized under R-F/R-M for stating true results — the finding is about hierarchy and presentation, not mathematical correctness
 
 ## Relationship to Other Skills
 

--- a/skills/math-notation-consistency/SKILL.md
+++ b/skills/math-notation-consistency/SKILL.md
@@ -50,47 +50,67 @@ required runtime context and not shipped with installed copies).
 1. Extract all `\newcommand`, `\renewcommand`, `\DeclareMathOperator` definitions from the preamble; build a macro-definition table.
 2. Extract all first-use-in-prose definitions (e.g., "let X denote …", 「\(f\) を〜とおく」); note section and location.
 3. For each macro in the definition table, check whether it appears in the document body; flag unused macros (NC-2).
-4. For each mathematical symbol appearing in a theorem statement or proof, check that it has a formal definition site earlier in the document (NC-1).
-   Also scan the abstract and conclusion for symbols — especially relation symbols such as ≺, ⊏ — that have no definition site anywhere in the document (NC-1, BLOCKING).
+4. For each nonstandard or document-specific symbol used in a load-bearing claim (a theorem/proposition/lemma/corollary statement, a proof step it depends on, or a claim in the abstract or conclusion), locate its canonical definition. Flag a missing definition, or two or more definition sites that assign incompatible content (NC-1, BLOCKING). A second passage that only restates the same canonical meaning is not a finding.
 5. Scan for multiple names applied to the same object (NC-3); compare against `known_aliases` if provided.
-6. Scan for the same symbol applied to different objects across the document's live scopes (NC-4).
-7. For each symbol whose definition site and first re-use are separated by more than one section, flag for back-reference check (NC-5).
+6. Scan for the same symbol applied to different objects within a live scope, asking whether a reader could plausibly assign two incompatible meanings at the point of use (NC-4).
+7. For each symbol reused after a gap, check whether its canonical definition is still readily recoverable from local context; if not, flag for back-reference (NC-5).
 8. Scan `\ref`, `\eqref`, `\autoref` for labels that do not match any defined `\label` in the document (NC-6).
 9. Scan subscript/superscript conventions for the same family of objects; flag inconsistent mixtures (NC-7).
 10. Produce a structured finding report.
 
 ## Rules
 
-**NC-1 — One formal definition site per symbol.**
-Every mathematical symbol used in the document must have exactly one formal definition site: either a `\newcommand` in the preamble with a corresponding prose definition in the body, or an explicit inline definition ("let X denote…", 「〜を X とおく」). A symbol with two definition sites (e.g., re-defined partway through the paper) is flagged BLOCKING. Note: NC-1 governs the *existence and uniqueness* of the definition; `math-claim-integrity` rule R-J governs whether a symbol is defined *before* its first use in a theorem statement.
+Each rule is tagged with a classification that sets a default severity: **invariant** — a violation is logically or structurally wrong — defaults to BLOCKING; **convention** — a strong norm with bounded exceptions — defaults to MINOR, escalating to BLOCKING when the violation obscures which meaning is canonical or creates a credible ambiguity in a load-bearing claim; **heuristic** — a review trigger requiring contextual judgement — defaults to ADVISORY, escalating per its own stated condition. A rule's own text overrides this default where it states a severity explicitly. When a defect triggers more than one rule, report each tag; the defect's severity for gating purposes is the maximum across triggered findings (BLOCKING > MINOR > ADVISORY > NOTE).
 
-**NC-2 — No orphaned macros.**
-Every macro defined in the LaTeX preamble via `\newcommand` or `\DeclareMathOperator` must appear at least once in the document body. A macro defined but never used is dead code that may represent a superseded notation — flag it for removal or documentation. Severity: MINOR.
+**NC-1 — Canonical-definition predicate.** *(invariant)*
+Every nonstandard or document-specific symbol used in a load-bearing claim — a theorem/proposition/lemma/corollary statement, a proof step it depends on, or a claim in the abstract or conclusion — must have a locatable canonical definition somewhere in the document. Flag two failure modes: (a) *missing definition* — no definition site exists anywhere; (b) *incompatible competing definitions* — two or more definition sites assign the symbol different mathematical content. The predicate targets locating one canonical meaning per symbol, not counting textual definition occurrences: a second passage that restates the same canonical meaning without changing it is not a finding. Note: NC-1 governs existence and uniqueness of canonical meaning; `math-claim-integrity` rule R-J governs whether a symbol is defined *before* its first use in a theorem statement.
 
-**NC-3 — One canonical term per concept.**
-Every named mathematical concept must have one canonical term used consistently across the document. If an object is referred to by multiple names (a full name, an abbreviation, and a symbol), each name must appear in a declared-equivalence sentence ("we write R for the small-scale limit and abbreviate it SSL"). Without such a declaration, aliases are flagged as NC-3 MINOR findings. Cross-language aliases are a common revision artifact and fall under this rule: a concept defined with a term in the document's main language later referred to by an undeclared equivalent in another language (e.g., a defined Japanese term later written in English, or vice versa) is an NC-3 finding — unify to the defined term. Argument-convention variants of the same operator (F(X,t) in the definition vs F(tX) in a later section) are also NC-3 findings unless the second form is explicitly declared (e.g., tX as the rescaled object with F(tX) := F(X,t)). This rule works in tandem with `math-claim-integrity` rule R-I: R-I checks conceptual *correctness* of the name at introduction; NC-3 checks *consistency* of the name thereafter.
+**NC-2 — No orphaned macros.** *(convention)*
+Every macro defined in the LaTeX preamble via `\newcommand` or `\DeclareMathOperator` must appear at least once in the document body. A macro defined but never used is dead code that may represent a superseded notation — flag it for removal or documentation.
 
-**NC-4 — No symbol reuse across scopes.**
-The same symbol (same LaTeX command or same rendered character) must not be used for two different mathematical objects within any live scope. Common violations: r used as both a continuous parameter and a discrete index; C used as both a constant and a specific matrix; n as both dimension and an index. When a symbol is deliberately reused in a new scope (e.g., a local variable in a proof), the new introduction must explicitly shadow the old one ("in this proof only, let r denote …").
+**NC-3 — One canonical term per concept.** *(convention)*
+Every named mathematical concept must have one canonical term used consistently across the document. If an object is referred to by multiple names (a full name, an abbreviation, and a symbol), each name must appear in a declared-equivalence sentence ("we write R for the small-scale limit and abbreviate it SSL"). Without such a declaration, aliases are flagged as NC-3 findings. Cross-language aliases are a common revision artifact and fall under this rule: a concept defined with a term in the document's main language later referred to by an undeclared equivalent in another language (e.g., a defined Japanese term later written in English, or vice versa) is an NC-3 finding — unify to the defined term. Argument-convention variants of the same operator (F(X,t) in the definition vs F(tX) in a later section) are also NC-3 findings unless the second form is explicitly declared (e.g., tX as the rescaled object with F(tX) := F(X,t)). This rule works in tandem with `math-claim-integrity` rule R-I: R-I checks conceptual *correctness* of the name at introduction; NC-3 checks *consistency* of the name thereafter.
 
-**NC-5 — Back-reference after section gap.**
-When a symbol is first defined in section M and reused in section N where N ≥ M+2, the first reuse in section N should include a back-reference to the definition (e.g., "(with the notation of Definition 2.3)", "(the S of equation (3))"). Flag first-reuse sites that lack any back-reference. Severity: MINOR. The gap threshold is two or more sections (not two pages or two paragraphs).
+**NC-4 — No symbol reuse across scopes.** *(heuristic)*
+The same symbol must not carry two incompatible meanings within a live scope. The test: can the reader plausibly assign two different meanings to the same notation at the point of use? Common violations: r as both a continuous parameter and a discrete index while both are live; C as both a generic constant and a specific matrix in overlapping context; n as both dimension and index at once. Reuse in a scope that has genuinely closed (the earlier meaning is no longer live) is not a defect; explicit shadowing ("in this proof only, let r denote …") removes any remaining ambiguity outright. Severity: MINOR when reuse creates a plausible misreading in a live scope; ADVISORY when disjointness is credible but arguable.
 
-**NC-6 — No dangling cross-references.**
-Every `\ref{label}`, `\eqref{label}`, `\autoref{label}` must resolve to a `\label{label}` defined elsewhere in the same document. After reordering sections or renaming theorem environments, dangling references are common. Severity: BLOCKING (since they produce "??" in the compiled PDF and may silently misdirect readers in draft form).
+**NC-5 — Back-reference after a gap.** *(heuristic)*
+A symbol's first reuse long after its definition is a review trigger, not a defect by itself. Flag the reuse when its canonical definition is no longer readily recoverable from local context at the point of reuse — e.g., enough intervening notation or subject matter that a reader would need to search back through the document. A short recap phrase ("with the notation of Definition 2.3", "the S of equation (3)") resolves the flag. Do not flag reuse solely because a fixed number of sections separates definition and reuse; recoverability, not section distance, is the trigger. Severity: MINOR when reuse is genuinely not recoverable from local context; no finding when it is.
 
-**NC-7 — Consistent subscript/superscript conventions.**
-For a family of related objects, subscript and superscript placement must be consistent. Example: if eigenvalues are written λ_r in most places but λ^r in one section, flag the inconsistency. Similarly, ν_- and ν⁻ (minus as subscript vs. superscript) for the same object must be unified. Severity: MINOR.
+**NC-6 — No dangling cross-references.** *(invariant)*
+Every `\ref{label}`, `\eqref{label}`, `\autoref{label}` must resolve to a `\label{label}` defined elsewhere in the same document. After reordering sections or renaming theorem environments, dangling references are common (they produce "??" in the compiled PDF and may silently misdirect readers in draft form).
+
+**NC-7 — Consistent subscript/superscript conventions.** *(convention)*
+For a family of related objects, subscript and superscript placement must be consistent. Example: if eigenvalues are written λ_r in most places but λ^r in one section, flag the inconsistency. Similarly, ν_- and ν⁻ (minus as subscript vs. superscript) for the same object must be unified.
 
 ## Examples
 
 ```
-NC-1 (undefined relation symbol in summary prose):
+NC-1 (missing definition — undefined relation symbol in summary prose):
 Conclusion: "the invariants are ordered I₁ ≺ I₂ ≺ I₃" — ≺ has no definition site
 anywhere in the document.
 Finding (BLOCKING): relation symbol ≺ used without a formal definition. Either define
          the order in the body, or replace with the explicit statement it abbreviates.
          Report the conclusion-level claim also to math-claim-integrity rule R-L.
+```
+
+```
+NC-1 (incompatible competing definitions):
+Section 2 (Definition 2.1): "let κ(X) denote the number of connected components of X"
+Section 5 (used in Theorem 5.3's proof): "since κ(X) bounds the covering dimension of X"
+         — the proof's argument only holds if κ(X) means the covering dimension
+         defined nowhere else, contradicting Definition 2.1.
+Finding (BLOCKING): κ has two incompatible meanings (component count vs. covering
+         dimension). Rename one usage or reconcile which definition Theorem 5.3
+         actually relies on.
+```
+
+```
+NC-1 (must not flag — harmless explanatory restatement):
+Section 2 (Definition 2.1): "let κ(X) denote the number of connected components of X"
+Section 5: "recall that κ(X) counts the components of X, so κ(X) = 1 for connected X"
+Finding: none — section 5 restates Definition 2.1's canonical meaning without changing
+         it; this is not a second definition site.
 ```
 
 ```
@@ -119,11 +139,40 @@ Finding: 平衡/balanced and 非平衡/unbalanced are undeclared alias pairs for
 ```
 
 ```
-NC-4:
-Section 1: r is defined as a continuous radius parameter
-Section 3: "let r be a root of the characteristic polynomial" (r as a fresh variable)
-Finding: r reused without explicit shadowing. In section 3, rename to ρ or add
-         "in this proof only, let r denote a root of …".
+NC-4 (defect — same live scope):
+Section 3, within one proof: "let r be the radius parameter fixed at the start of
+this section" ... two paragraphs later, same proof: "let r index the eigenvalues
+of A" — both meanings are live in the same argument.
+Finding: r reused without explicit shadowing while the outer meaning is still live.
+         Rename the index to ρ or add "in this step only, let r denote …".
+```
+
+```
+NC-4 (must not flag — harmless reuse in a disjoint scope):
+Section 1: r is defined as a continuous radius parameter, used throughout §1–2.
+Section 3 (a self-contained lemma proof, §1–2's r never referenced again):
+"let r be a root of the characteristic polynomial" — the proof neither uses nor
+could be confused with the §1 radius, and the lemma's scope closes at proof's end.
+Finding: none — §1's r is no longer live at the point of reuse, and the new r is
+         confined to a proof that does not reference the earlier object.
+```
+
+```
+NC-5 (not recoverable — flag):
+Definition 2.3 introduces S. Sections 3–6 develop unrelated machinery using
+different notation throughout. Section 7 states "since S is nonempty, …" with no
+recap and no notation shared with Definition 2.3's context.
+Finding (MINOR): reuse of S in §7 is not locally recoverable — add "(the S of
+         Definition 2.3)" or restate its defining property.
+```
+
+```
+NC-5 (recoverable — must not flag):
+Definition 2.3 introduces S in terms of a filtration {F_i} that section 4 (two
+sections later) is still actively discussing using the same {F_i} notation; the
+sentence reusing S reads "the resulting S, built from the same {F_i} as above, …".
+Finding: none — the local context (shared {F_i} notation, explicit "as above")
+         keeps Definition 2.3's meaning recoverable despite the section gap.
 ```
 
 ```
@@ -143,7 +192,7 @@ Finding: Inconsistent placement. Unify to the form matching the preamble macro.
 
 Default: review-only. Produce a finding report listing:
 - Rule tag (NC-1 through NC-7)
-- Severity: BLOCKING (NC-1 multi-definition, NC-6 dangling refs) / MINOR (NC-2, NC-3, NC-5, NC-7) / ADVISORY (NC-4 when shadowing is arguable)
+- Classification (invariant / convention / heuristic — see Rules) and Severity: BLOCKING / MINOR / ADVISORY, following the default-severity mapping above unless the rule states otherwise
 - Location: line number, section heading, or macro name
 - One-sentence description
 - Concrete fix suggestion
@@ -156,7 +205,9 @@ Before finishing, verify:
 - NC-6 is checked against the *current* document's `\label` set, not a cached or partial read
 - NC-2 findings distinguish unused macros from macros used only in other macros (a macro used only inside another `\newcommand` is technically "used" even if not directly in prose)
 - NC-3 findings do not flag declared equivalences (where the author explicitly stated the alias)
-- NC-4 findings do not flag standard multi-use notation (e.g., i as imaginary unit in one context and index in another within separate, non-overlapping sections) — only flag within a live scope
+- NC-1 findings do not merely count definition-phrase occurrences: a second passage restating the same canonical meaning is not a finding, only a genuinely incompatible second meaning is
+- NC-4 findings turn on whether a competing meaning is actually live at the point of reuse, not on whether the same character was ever reused anywhere in the document
+- NC-5 findings turn on local recoverability, not on a fixed section-count gap
 
 ## Relationship to Other Skills
 


### PR DESCRIPTION
Closes #133

Implements the `math-notation-consistency` and `math-claim-integrity` slice of the #126 mathematical-writing audit, as one coordinated pair per the parent's requirement to rewrite these two together.

## Validation

- `iconv -f UTF-8 -t UTF-8` on both files: valid UTF-8, no errors.
- `git diff --stat`: `skills/math-claim-integrity/SKILL.md | 98 ++++++++++++++++++++++------`, `skills/math-notation-consistency/SKILL.md | 103 ++++++++++++++++++++++--------` (154 insertions, 47 deletions).
- Manually verified both `## Design intent` capsules and the `docs/skill-rationales/math-writing.md` rationale link (added by #135) are unchanged and present in both files.
- Manually verified every NC/R rule tag referenced in Output/Quality-Check/cross-skill boundary statements still exists after the edit (including the newly added R-M).
- Manually verified the three cross-skill division-of-labour statements read consistently on both sides: NC-1↔R-J, NC-3↔R-I, R-L↔NC-1.
- Checked `wabun-math-style/SKILL.md`'s reference to NC-3 and `deslop-prose/SKILL.md`'s reference to R-F (the only external files referencing tags in these two skills) — both still resolve correctly; neither file was touched.

### Before/after counts

| File | Lines (before → after) | Words (before → after) | Approx. tokens (chars/4, before → after) |
|---|---|---|---|
| `math-notation-consistency/SKILL.md` | 166 → 217 | 1873 → 2575 | ~3123 → ~4272 |
| `math-claim-integrity/SKILL.md` | 162 → 218 | 2084 → 3081 | ~3531 → ~5265 |

Both files grow net because the required additions (rule classification for every rule, a new rule, and ~10 mandated test-case examples) outweigh the repetition removed. No existing anti-pattern target, trigger, or output-contract field was cut to make room; see the "Compression only" notes below for what was in fact tightened.

## Semantic changes vs. compression, per file

### `skills/math-notation-consistency/SKILL.md`

**Semantic changes:**
- NC-1 reformulated from "exactly one formal definition site per symbol" to the operational predicate: every nonstandard/document-specific symbol used in a load-bearing claim has a locatable canonical definition; flag missing definitions and incompatible competing definitions. Harmless explanatory restatement is explicitly not a finding — this was previously undefined behavior that could be read as a mechanical occurrence count.
- NC-4 (symbol reuse across scopes) reframed around a single test — "can the reader plausibly assign two incompatible meanings at the point of use" — replacing the previous scope-boundary description; no exception catalogue added.
- NC-5 (back-reference after gap) changed from a mechanical "N ≥ M+2 sections" trigger to a recoverability test: flag only when the definition is no longer readily recoverable from local context.
- Added rule classification (invariant / convention / heuristic) per rule, driving a default severity mapping, plus explicit precedence when multiple rules match the same defect.
- Added test cases: incompatible competing definitions (NC-1), harmless explanatory restatement that must not be flagged (NC-1), harmless reuse in a disjoint scope that must not be flagged (NC-4), and a recoverable-vs-non-recoverable pair for back-reference after a gap (NC-5).

**Compression only:**
- Per-rule "Severity: ..." boilerplate folded into the classification-driven default-severity paragraph at the top of `## Rules`, stated once instead of repeated verbatim in NC-2/NC-3/NC-6/NC-7.
- The old "i as imaginary unit" exception example in Quality Check replaced with the general live-scope test statement (removes one example-based exception without losing the underlying rule).

### `skills/math-claim-integrity/SKILL.md`

**Semantic changes:**
- R-F (theorem hierarchy) reframed as a functional test (independent scholarly significance, advertisement in title/abstract/intro, independent reusability, sole-input role) instead of leading with environment-name labeling; classified as `convention` escalating to `BLOCKING` when presentation flattens the actual hierarchy, keeping the exception for independently significant intermediate results.
- Added new rule **R-M — Contribution-list mapping discipline**: every §1 contribution-list item must map to its formal result, prior baseline, concrete gain, independent-significance justification, and granularity-duplication check; escalates to BLOCKING when the abstract/introduction materially misrepresents the paper's main scholarly contribution. This is the primary semantic addition requested by #126/#133.
- Added rule classification (invariant / convention / heuristic) per rule, with the same default-severity mapping as `math-notation-consistency`, plus explicit R-F/R-M co-firing precedence (report both tags rather than treating as duplicates).
- R-H explicitly reconfirmed as ADVISORY-by-default, escalating only to MINOR on circularity / use-before-definition / concrete readability failure — never BLOCKING (fixes a stale Quality-Check bullet that mismatched this behavior).
- Added test cases: a legitimately theorem-level intermediate result that must not be flagged (R-F), a contribution list double-counting proof infrastructure (R-M), a correctly structured contribution list that must not be flagged (R-M), and a mathematically-true paper whose presentation still misrepresents its contribution hierarchy (R-F + R-M, BLOCKING).
- Frontmatter `description` and a `Use when` bullet extended to name contribution-list discipline explicitly, since R-M is a new primary trigger surface.

**Compression only:**
- Per-rule severity boilerplate folded into the shared classification-driven default-severity paragraph, same pattern as the notation-consistency file.

## Preserved (not touched)

- Both `## Design intent` capsules and the `docs/skill-rationales/math-writing.md` rationale link from #135.
- All frontmatter descriptions and `Use when` triggers (only additive, no removals).
- Output contracts (rule-tag enumerations, BLOCKING/MINOR/ADVISORY/NOTE severities, report fields).
- R-A, R-B, R-D, R-E, R-G, R-I, R-J, R-K, R-L (math-claim-integrity) and NC-2, NC-3, NC-6, NC-7 (math-notation-consistency) — retained at full strength, only reformatted with classification tags.
- `wabun-math-style/SKILL.md` and `deslop-prose/SKILL.md` — untouched; their cross-references to NC-3 and R-F still resolve.