### PR TITLE
math-semantic-preservation: add meaning-preserving mathematical edit review skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ Each skill must live at `skills/<skill-name>/SKILL.md`.
 
 - `lean-formalization-discipline`: keep Lean / Mathlib proofs sound and axiom-clean while refactoring — no `sorry` on false statements, honest `sorry` over hidden axioms, self-contained in the repo, and `lake build` + `#print axioms` re-verified every commit
 
+### Mathematical writing
+
+- `math-claim-integrity`: audit the structural and logical integrity of a mathematics paper — quantifier scope, proof/computation honesty, theorem hierarchy, contribution-list discipline, stale claims, and standing assumptions
+- `math-notation-consistency`: audit a LaTeX mathematics document for notation drift — definition sites, aliases, symbol reuse across scopes, and back-references after gaps
+- `math-semantic-preservation`: review or rewrite mathematical prose so edits, paraphrases, and terminology migrations preserve the exact source meaning — referent identity, operation vs result, quantifier and equality mode, provenance, and notation role
+- `wabun-math-style`: detect and correct Japanese-language anti-patterns in mathematical writing — epistemic hedges, tense and voice discipline, connective and particle logic, borrowed vocabulary, terminology SoT drift, and concept-preserving translation
+
 ### Repository guidance
 
 - `growing-agents-md`: seed, lint, or update a compact canonical `AGENTS.md` with deterministic guardrails

--- a/docs/skill-rationales/math-writing.md
+++ b/docs/skill-rationales/math-writing.md
@@ -4,14 +4,16 @@ Maintenance-only document. It is not runtime skill context and is not copied int
 installed skill directories; it exists so a maintainer or reviewer can recover why
 a rule exists without reconstructing issue history.
 
-Covers three skills:
+Covers four skills:
 
 - `skills/wabun-math-style/SKILL.md`
 - `skills/math-notation-consistency/SKILL.md`
 - `skills/math-claim-integrity/SKILL.md`
+- `skills/math-semantic-preservation/SKILL.md`
 
 Original implementation: PR [#118](https://github.com/t-uda/skills/pull/118).
 Latest semantic revision: [#149](https://github.com/t-uda/skills/issues/149).
+`math-semantic-preservation` added: [#153](https://github.com/t-uda/skills/issues/153).
 Future semantic rewrites need their own issue. This document
 preserves *design intent*; it must not silently weaken any target behaviour or
 drop any "Protected behaviour" clause when edited.
@@ -303,7 +305,84 @@ cosmetic naming preferences. The skill exists to prevent flat, inflated
 presentations of AI-generated results and to make the paper's genuine
 scholarly contribution legible.
 
-## 6. Relationship among the three skills
+## 6. `math-semantic-preservation`: meaning-preserving mathematical edits
+
+### Originating failure mode
+
+Live review of a large mathematical prose corpus exposed edits that were
+linguistically smoother, internally consistent, and mechanically valid while
+no longer describing the same mathematics. Representative failures: the third
+argument of a trilinear form described as the third factor of a two-factor
+tensor product; an almost-everywhere assertion rewritten as apparent pointwise
+equality; composition with a continuous linear map renamed "pushforward";
+convolution described as an operation performed separately at each point; a
+restriction operation conflated with the restricted object; one overloaded
+term replaced uniformly although its occurrences denoted a Fourier truncation
+residual, an out-of-box coefficient sum, an orthogonal residual, a
+physical-space exterior part, and eventual sequence behaviour; a superscript
+index read as a power; a statement, proof explanation, link label, glossary,
+and audit record edited inconsistently for one concept; a property attributed
+to the wrong structure while the final conclusion stayed superficially
+plausible. These are semantic-preservation defects, not prose-style defects.
+
+### Ownership boundary
+
+`math-claim-integrity` owns whether a claim is supported at the strength its
+proof establishes; `math-notation-consistency` owns document-wide notation
+bookkeeping; `wabun-math-style` JP-16/JP-17 own terminology SoT conflicts and
+translation or source-naming events. `math-semantic-preservation` owns whether
+an edit, monolingual paraphrase, terminology migration, or explanatory
+description preserves the semantic content fixed by its source anchor. One
+defect is reported at exactly one layer — the layer whose invariant is
+actually broken.
+
+### Compact live examples
+
+Maintenance evidence and realistic validation material (full
+`owner/repository#number` form; not copied into the runtime skill):
+
+- `uda-lab/lean-pde-notes#51` — source proofreading campaign; umbrella context
+  for the mathematically unsafe paraphrases and migrations reviewed.
+- `uda-lab/lean-pde-notes#55` — the overloaded Japanese 尾部 problem that
+  motivated a corpus-wide terminology decision over mechanical replacement.
+- `uda-lab/lean-pde-notes#56` — explicit terminology decision and
+  classification task distinguishing Fourier truncation residuals, out-of-box
+  coefficient sums or families, orthogonal residuals, physical-space exterior
+  parts, and eventual sequence behaviour; primary live example for MS-7.
+- `uda-lab/lean-pde-notes#57` — MS-2 and MS-4 examples: composition described
+  as pushforward; time convolution described as if points were convolved; a
+  definition sentence completed only once its data and predicate were explicit.
+- `uda-lab/lean-pde-notes#58` — MS-1, MS-3, MS-5, MS-7 examples: trilinear-form
+  argument confused with a tensor factor; an a.e. representative statement
+  rewritten with an unclear pointwise referent; mechanical replacements
+  introducing pseudo-technical wording; an audit ledger recording wording
+  different from the change it documented.
+- `uda-lab/lean-pde-notes#59` — MS-2 and MS-7 examples: restriction to a ball
+  complement separated from the resulting exterior part; the canonical pair
+  球内部分/球外部分 kept synchronized; migration completed with glossary and
+  lint protection while compatibility-only identifiers containing `tail` were
+  intentionally retained.
+
+### Protected behaviour
+
+Future compression or generalisation must preserve the following:
+
+1. Natural language fluency must never be treated as evidence that
+   mathematical meaning was preserved.
+2. Definitions, formulas, types, and uses outrank labels and identifier names
+   as semantic evidence.
+3. Terminology migrations must classify occurrences before replacement.
+4. Pointwise, almost-everywhere, eventual, and uniform statements must remain
+   distinct.
+5. Argument positions, tensor factors, coordinates, indices, and exponents
+   must remain distinct.
+6. Operations must remain distinct from their results.
+7. Related human-facing descriptions of one concept must be synchronized
+   without requiring compatibility identifiers to be renamed.
+8. The skill must not become a general theorem prover or duplicate Japanese
+   style, notation bookkeeping, or paper-level claim-integrity review.
+
+## 7. Relationship among the four skills
 
 Ownership boundaries to preserve:
 
@@ -314,7 +393,10 @@ Ownership boundaries to preserve:
   definition locality, and notation reuse.
 - `math-claim-integrity` owns claim structure, proof/evidence boundaries,
   result hierarchy, and contribution hierarchy.
+- `math-semantic-preservation` owns semantic fidelity of edits, paraphrases,
+  explanatory descriptions, and terminology migrations against their semantic
+  anchor.
 
 A wording pattern may reveal a deeper claim defect, but a finding should state
 which layer is actually broken instead of duplicating the same rule across all
-three skills.
+four skills.

--- a/skills/README.md
+++ b/skills/README.md
@@ -42,3 +42,4 @@ Current skills:
 - lean-formalization-discipline
 - research-significance
 - exposition-flow
+- math-semantic-preservation

--- a/skills/math-claim-integrity/SKILL.md
+++ b/skills/math-claim-integrity/SKILL.md
@@ -41,6 +41,7 @@ Do not use this skill for:
 - Symbol-table drift across sections → use `math-notation-consistency`
 - Japanese-specific language anti-patterns → use `wabun-math-style`
 - Discussion-history artifacts in planning docs → use `deslop-history`
+- Whether an edit, paraphrase, or terminology migration preserves the semantic content of its source (referent identity, operation vs result, quantifier or equality mode changed by an edit) → use `math-semantic-preservation`
 
 ## Inputs
 
@@ -216,3 +217,4 @@ Before finishing, verify:
 - Use `wabun-math-style` for Japanese-language anti-patterns (epistemic hedges, verb tense, particle misuse).
 - Use `math-notation-consistency` for symbol drift across sections, orphaned macros, or alias detection.
 - Use `deslop-history` when a planning or notes artifact leaks process history or prior-draft residue.
+- Use `math-semantic-preservation` when an edit or explanatory description changed a source statement's meaning or mode; this skill remains responsible when the claim itself exceeds what the proof establishes (its rule MS-4 defers claim-strength defects here).

--- a/skills/math-notation-consistency/SKILL.md
+++ b/skills/math-notation-consistency/SKILL.md
@@ -38,6 +38,7 @@ required runtime context and not shipped with installed copies).
 - For quantifier scope errors, theorem hierarchy, or proof/computation distinction — use `math-claim-integrity`
 - For Japanese-language anti-patterns — use `wabun-math-style`
 - For prose inflation — use `deslop-prose`
+- For prose assigning the wrong mathematical role to notation (a family index read as an exponent, an argument position read as a tensor factor) — use `math-semantic-preservation`; this skill audits bookkeeping, not semantic interpretation
 
 ## Inputs
 
@@ -215,3 +216,4 @@ Before finishing, verify:
 - Use `wabun-math-style` for Japanese-language anti-patterns.
 - Use `deslop-prose` for prose inflation.
 - NC-1 (existence/uniqueness of definition) complements `math-claim-integrity` rule R-J (defined-before-use in theorem statements): R-J checks completeness of theorem statements; NC-1 checks uniqueness of the definition site.
+- NC-7 owns inconsistent typography for the same family of objects; `math-semantic-preservation` rule MS-6 owns an incorrect semantic reading of otherwise consistent notation (e.g. a family index described as a power).

--- a/skills/math-semantic-preservation/SKILL.md
+++ b/skills/math-semantic-preservation/SKILL.md
@@ -46,7 +46,7 @@ Never assume an identifier name is semantically authoritative when its type, def
 
 ## Rule classification and severity
 
-Each rule is tagged with a classification that sets a default severity: **invariant** — a violation means the prose no longer describes the source's mathematics — defaults to BLOCKING; **convention** — a strong norm with bounded exceptions — defaults to MINOR, escalating per the rule's own condition. A rule's own text overrides this default where it states a severity explicitly. When a defect triggers more than one rule, report each tag; the defect's severity for gating purposes is the maximum across triggered findings (BLOCKING > MINOR > ADVISORY > NOTE).
+Each rule is tagged with a classification that sets a default severity: **invariant** — a violation means the prose no longer describes the source's mathematics — defaults to BLOCKING; **convention** — a strong norm with bounded exceptions — defaults to MINOR, escalating per the rule's own condition. A rule's own text overrides this default where it states a severity explicitly. When a defect triggers more than one rule, report each tag; the defect's severity for gating purposes is the maximum across triggered findings (BLOCKING > MINOR > ADVISORY).
 
 ## Procedure
 

--- a/skills/math-semantic-preservation/SKILL.md
+++ b/skills/math-semantic-preservation/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: math-semantic-preservation
+description: Review or rewrite mathematical prose so an edit, paraphrase, terminology migration, or explanatory description preserves the exact mathematical meaning fixed by its semantic source — referent identity, operation versus result, domain/codomain and representation level, quantifier and equality mode, role and provenance, notation role, and classified-before-replacement terminology migration with concept-cluster synchronization — without auditing claim-versus-proof strength (use math-claim-integrity), notation bookkeeping (use math-notation-consistency), Japanese style or translation events (use wabun-math-style), or audience prerequisites and ordering (use exposition-flow).
+---
+
+# Math Semantic Preservation
+
+Review or rewrite mathematical prose while preserving the exact mathematical meaning of the source. An edit can be linguistically smoother, internally consistent, and mechanically valid while no longer describing the same mathematics; this skill detects and repairs that failure. It is field-agnostic and language-agnostic: it audits semantic fidelity against definitions, formulas, formal declarations, and source passages, not prose style or mathematical correctness of the source itself.
+
+## Design intent
+
+Live review of a large mathematical prose corpus exposed a recurring failure mode: locally plausible wording changes silently altered the object being discussed, conflated an operation with its result, changed an almost-everywhere assertion into an apparent pointwise one, reused an established term for a different operation, misread an index as an exponent, or replaced one overloaded term uniformly across occurrences that denoted distinct objects. Natural language fluency is never evidence that mathematical meaning was preserved. Maintainer note: see
+[`docs/skill-rationales/math-writing.md`](https://github.com/t-uda/skills/blob/main/docs/skill-rationales/math-writing.md)
+in the source repository for the full design rationale (maintenance-only; not
+required runtime context and not shipped with installed copies).
+
+## Use when
+
+- Paraphrasing, smoothing, or restructuring mathematical prose against an authoritative source (definitions, formulas, theorem statements, formal declarations)
+- Reviewing a diff or edit of mathematical prose for meaning drift
+- Performing or reviewing a document- or corpus-wide terminology migration, especially of an overloaded term
+- Generating documentation or explanatory prose from formal sources (Lean, Coq, Isabelle, Agda, or similar)
+- Synchronizing the statement, proof explanation, notes, link labels, glossary, and audit records that describe one mathematical concept
+- An explanatory description assigns a role to notation, an argument position, or a datum whose definition should be checked first
+
+## Do not use
+
+- For whether a claim is supported at the strength its proof establishes, theorem hierarchy, or claim/proof boundaries → use `math-claim-integrity`
+- For definition sites, aliases, symbol reuse across scopes, subscript/superscript typography, or dangling references → use `math-notation-consistency`
+- For Japanese-language anti-patterns, terminology SoT conflicts, and translation or source-naming events (JP-16/JP-17) → use `wabun-math-style`
+- For audience prerequisites, dependency ordering, and self-containment of an exposition → use `exposition-flow`
+- For prose inflation or hype → use `deslop-prose`
+
+One defect, one layer: report the skill whose invariant is actually broken, never duplicate findings. `wabun-math-style` JP-17 owns the translation or source-naming event; this skill owns the corresponding language-agnostic defect when it arises during **monolingual** paraphrase, corpus editing, documentation generation, or terminology migration rather than translation.
+
+## Inputs
+
+- `artifact` — the mathematical prose, documentation, annotation corpus, or document section to review
+- `edit_base` — the wording before the edit, when reviewing a change or diff (optional)
+- `semantic_source` — definitions, formulas, theorem statements, formal declarations, source-language passages, or other authoritative material that fixes the intended meaning
+- `related_artifacts` — linked statements, proofs, notes, glossary entries, labels, or audit records that describe the same concept (optional)
+- `terminology_sot` — canonical terminology and permitted aliases (optional)
+- `formal_source` — Lean, Coq, Isabelle, Agda, or other formal declarations used as semantic evidence (optional)
+
+Never assume an identifier name is semantically authoritative when its type, definition, formula, or use says otherwise: definitions, formulas, types, and uses outrank labels and identifier names as semantic evidence.
+
+## Rule classification and severity
+
+Each rule is tagged with a classification that sets a default severity: **invariant** — a violation means the prose no longer describes the source's mathematics — defaults to BLOCKING; **convention** — a strong norm with bounded exceptions — defaults to MINOR, escalating per the rule's own condition. A rule's own text overrides this default where it states a severity explicitly. When a defect triggers more than one rule, report each tag; the defect's severity for gating purposes is the maximum across triggered findings (BLOCKING > MINOR > ADVISORY > NOTE).
+
+## Procedure
+
+1. **Identify the semantic anchor.** Determine which definition, formula, formal declaration, theorem statement, or source passage fixes the meaning of the edited or reviewed text.
+2. **Build a compact semantic record.** For each load-bearing edited span, record only the relevant fields: referent, operation or relation, domain and codomain, quantifier or equality mode, assumptions and provenance, notation role.
+3. **Classify overloaded terminology by occurrence.** Before any repository-wide or document-wide replacement, classify each occurrence by the mathematical object it denotes. Do not begin with a one-to-one lexical substitution table.
+4. **Compare the edit with the semantic record.** Check whether the new prose preserves every load-bearing field. Natural wording is not evidence of semantic equivalence.
+5. **Inspect the concept cluster.** When the same concept appears in a statement, proof explanation, note, link label, glossary, or audit record, verify that all members of the cluster use compatible terminology and describe the same object.
+6. **Report or repair only the semantic defect.** Do not broaden the task into general prose polishing, theorem proving, or document-wide notation cleanup.
+
+## Rules
+
+**MS-1 — Preserve referent identity.** *(invariant)*
+The edited text must refer to the same mathematical object as the semantic source. Flag an edit that replaces one object with a related but distinct object, including: a function with its equivalence class, a subspace with one of its elements, a coefficient family with its sum, or a formal argument position with a tensor factor. Default severity: BLOCKING.
+
+**MS-2 — Distinguish operations from results.** *(invariant)*
+An operation and the object produced by that operation must not be conflated. Examples: restriction versus the restricted part, projection versus the projected component, truncation versus truncation residual, composition versus pushforward, convolution as an integral operation versus the resulting curve. Default severity: BLOCKING.
+
+**MS-3 — Preserve domain, codomain, and representation level.** *(invariant)*
+The edit must preserve where an object lives and at what representation level a statement is made. In particular: distinguish an L^p equivalence class from a chosen representative, distinguish the value space from the function space, and do not describe a map as acting on a domain different from the one fixed by its definition. Default severity: BLOCKING.
+
+**MS-4 — Preserve quantifier and equality mode.** *(invariant)*
+The edit must preserve universal, existential, and eventual quantification; pointwise versus almost-everywhere equality; equality versus convergence; implication versus case selection; and fixed-parameter versus uniform assertions. `math-claim-integrity` remains responsible when the claim itself exceeds what the proof establishes; this rule is responsible when an edit or explanatory description changes the source claim's mode. Default severity: BLOCKING.
+
+**MS-5 — Preserve role and provenance.** *(invariant)*
+The edit must correctly identify which assumption, structure, package, field, or previous result supplies a datum; which numbered position is an argument, coordinate, factor, component, or stage; and which construction a later property belongs to. Do not infer ownership from nearby implementation structure or identifier names alone. Severity: BLOCKING when the wrong source changes the mathematical dependency; MINOR when the dependency remains unambiguous but the explanation is locally inaccurate.
+
+**MS-6 — Interpret notation by definition, not typography alone.** *(invariant)*
+A superscript is not automatically a power, a subscript is not automatically an index, and a number in an identifier is not automatically the number of a displayed factor. Determine the role from the definition, type, formula, and use. `math-notation-consistency` owns inconsistent typography for the same family (NC-7); this rule owns an incorrect semantic interpretation of otherwise consistent notation. Default severity: BLOCKING.
+
+**MS-7 — Classify before terminology migration and synchronize the concept cluster.** *(convention for cluster synchronization; invariant when the replacement itself collapses distinct concepts)*
+A terminology migration must classify occurrences by referent before replacement. After choosing the context-specific terms, update all relevant members of the concept cluster: statement, proof explanation, note, link display text, glossary, and audit or migration record. Do not require every repository metadata field or compatibility identifier to be renamed — the scope is human-facing mathematical content and records that claim to describe the applied migration. Severity: cluster-synchronization defects default MINOR, escalating to BLOCKING when inconsistent terms identify different mathematical objects; a replacement that collapses distinct concepts into one term is BLOCKING.
+
+## Examples
+
+```
+MS-1 (argument position read as tensor factor):
+Source: B(u, v, w) is a trilinear form applied to the two-factor product u ⊗ v.
+Edit:   "w is the third factor of the tensor product."
+Finding (BLOCKING): the third argument of the trilinear form was rewritten as a
+         third tensor factor; the displayed product has only two factors.
+```
+
+```
+MS-4 (a.e. assertion made pointwise):
+Source: f = g in L^2, i.e. f(x) = g(x) for almost every x.
+Edit:   "f(x) equals g(x) at every point x."
+Finding (BLOCKING): almost-everywhere equality rewritten as unqualified
+         pointwise equality. Restore the a.e. qualifier or the L^2 statement.
+```
+
+```
+MS-2 (established term reused for a different operation):
+Source: T ∘ f, composition of f with a continuous linear map T.
+Edit:   "the pushforward of f under T."
+Finding (BLOCKING): "pushforward" names an established, different operation.
+         Say "the composition T ∘ f" (or "post-composition with T").
+```
+
+```
+MS-2 + MS-3 (operation conflated with its result):
+Source: the restriction of the field to the complement of the ball, yielding
+        the exterior part.
+Edit:   "the exterior part is the restriction domain."
+Finding (BLOCKING): the restriction operation, its domain, and the resulting
+         restricted object are three different things; name each correctly.
+```
+
+```
+MS-7 (lexical migration without occurrence classification):
+Plan: replace every occurrence of "tail" with one chosen term.
+Corpus: "tail" denotes a Fourier truncation residual in §2, an out-of-box
+        coefficient sum in §3, a physical-space exterior part in §5, and
+        eventual sequence behaviour in §7.
+Finding (BLOCKING): one-to-one substitution collapses distinct objects.
+         Classify each occurrence by referent, then choose per-context terms.
+```
+
+```
+MS-6 (index read as exponent):
+Source: Δ^j denotes the j-th member of a family of operators (j an index).
+Edit:   "Δ raised to the power j."
+Finding (BLOCKING): the superscript is a family index, not exponentiation;
+         describe it per the family's definition.
+```
+
+```
+MS-7 (audit record out of sync):
+Glossary records "residual" as the applied replacement; the corpus edit
+actually used "remainder term" throughout.
+Finding (MINOR, escalating if the terms denote different objects): the record
+         claims a migration different from the one applied; synchronize it.
+```
+
+```
+MS-5 (property attributed to the wrong structure):
+Source: the boundedness constant is supplied by the assumption on the measure,
+        not by the operator's own definition.
+Edit:   "by the definition of the operator, the constant is bounded."
+Finding (BLOCKING if the dependency changes, MINOR otherwise): the datum's
+         provenance was reassigned; cite the supplying assumption.
+```
+
+```
+MS-2 (must not flag — established term with its standard meaning):
+"the kernel of the map", "the support of the measure", "the pushforward of the
+measure under a measurable map" — each used with its standard meaning.
+Finding: none — established terminology matching the established operation.
+```
+
+```
+MS-7 (must not flag — intentional context-specific split):
+Two distinct objects that shared one ambiguous source word are deliberately
+given two different terms, with the split recorded in the glossary.
+Finding: none — the split preserves referent distinctions; that is the goal.
+```
+
+```
+MS-3 / MS-4 (must not flag — explicit representative selection):
+"Fix Borel representatives of f and g; then f(x) = g(x) for a.e. x."
+Finding: none — the representation level is explicit and the equality mode
+         is stated.
+```
+
+```
+MS-7 (must not flag — compatibility-only identifier retained):
+A formal-source identifier keeps a historical name for compatibility while all
+human-facing prose uses the canonical terminology.
+Finding: none — compatibility identifiers are out of the synchronization scope.
+```
+
+```
+MS-7 (must not flag — scoped informal alias in the glossary):
+The glossary permits both the precise formal term and a clearly scoped
+informal explanation of the same concept.
+Finding: none — permitted, scoped aliases are not drift.
+```
+
+```
+MS-3 (must not flag — codomain detail omitted next to the displayed map):
+"the map sends u to its average" immediately below the displayed map
+u ↦ (1/|Q|)∫_Q u with explicit codomain.
+Finding: none — the omitted detail is explicit in the immediately displayed
+         map and cannot be misread.
+```
+
+## Output
+
+Default: review-only. Produce a structured finding report listing:
+- Rule tag (MS-1 through MS-7)
+- Classification (invariant / convention — see Rules) and Severity: BLOCKING / MINOR / ADVISORY, following the default-severity mapping above unless the rule states otherwise
+- Location: section heading, environment label, or line
+- Semantic anchor: the definition, formula, declaration, or source passage that fixes the intended meaning
+- Field that changed: `referent`, `operation`, `domain`, `quantifier`, `provenance`, or `notation role`
+- A concrete correction
+
+In fix mode, edit only the affected mathematical prose and synchronized concept-cluster entries. Do not rename formal identifiers, theorem labels, file names, or compatibility APIs without explicit instruction.
+
+## Quality Check
+
+Before finishing, verify:
+- Every finding names its semantic anchor and the field that changed
+- No finding rests on fluency or naturalness judgments — only on comparison with the semantic record
+- Any terminology migration classified occurrences by referent before replacement was assessed
+- No duplicate finding for an event owned by `wabun-math-style` (JP-16/JP-17 translation or SoT events), `math-notation-consistency` (bookkeeping), or `math-claim-integrity` (claim strength)
+- No compatibility identifier, theorem label, file name, or metadata field was demanded renamed
+- Pointwise, almost-everywhere, eventual, and uniform statements remain distinct in every proposed correction
+
+## Relationship to Other Skills
+
+- `math-claim-integrity` owns whether a claim is supported at the strength its proof establishes; this skill owns whether an edit changed the source claim's meaning or mode (MS-4 defers claim-strength defects there).
+- `math-notation-consistency` owns document-wide notation bookkeeping — definition sites, aliases, scope, typography (NC-7); this skill owns whether prose assigns the correct mathematical role to otherwise consistent notation (MS-6).
+- `wabun-math-style` owns Japanese language review, terminology SoT conflicts, and translation or source-naming events (JP-16/JP-17); this skill owns the language-agnostic semantic defect in monolingual paraphrase, corpus editing, documentation generation, or terminology migration.
+- `exposition-flow` owns audience prerequisites and dependency order; it does not determine whether a local mathematical paraphrase preserves the source meaning — that is this skill.
+- Do not emit duplicate findings for one defect: report the layer whose invariant is actually broken.

--- a/skills/wabun-math-style/SKILL.md
+++ b/skills/wabun-math-style/SKILL.md
@@ -30,8 +30,9 @@ A Japanese mathematics paper, preprint, or lecture note (LaTeX with ltjsarticle,
 - Symbol-table consistency, aliases, and definition locality — use `math-notation-consistency`. (JP-14's alias case cross-reports as NC-3.) JP-16 owns a conflict with a supplied terminology SoT; do not duplicate that conflict as NC-3.
 - Language-agnostic prose inflation (hype, unsupported claims, decorative structure) — use `deslop-prose`; it composes with this skill rather than overlapping it.
 - Removing process history from planning/notes documents — use `deslop-history`.
+- Language-agnostic semantic drift during monolingual paraphrase, corpus editing, documentation generation, or terminology migration — use `math-semantic-preservation`. JP-16/JP-17 keep ownership of translation and source-naming events.
 
-A wording pattern here may reveal a deeper claim defect; state which layer is actually broken rather than duplicating a finding across skills. Cross-report a distinct document-wide alias or definition-locality defect to `math-notation-consistency`, and a distinct claim-scope or truth-value defect to `math-claim-integrity`; JP-16/JP-17 own the terminology or translation event itself.
+A wording pattern here may reveal a deeper claim defect; state which layer is actually broken rather than duplicating a finding across skills. Cross-report a distinct document-wide alias or definition-locality defect to `math-notation-consistency`, and a distinct claim-scope or truth-value defect to `math-claim-integrity`; JP-16/JP-17 own the terminology or translation event itself, while a monolingual paraphrase or migration event belongs to `math-semantic-preservation` — never report both for one defect.
 
 ## Inputs
 


### PR DESCRIPTION
Closes #153

> **Stacked PR** — based on `issue-151-exposition-flow` (#154) because both PRs touch `skills/README.md` and the root `README.md`, and this skill's boundary sections reference `exposition-flow`. GitHub will retarget this PR to `main` when #154 merges.

## Summary

Adds `skills/math-semantic-preservation/SKILL.md`, owning whether an edit, monolingual paraphrase, terminology migration, or explanatory description preserves the exact mathematical meaning fixed by its semantic source.

- Procedure: semantic anchor → compact semantic record (referent, operation/relation, domain+codomain, quantifier/equality mode, assumptions+provenance, notation role) → classify overloaded terms **by occurrence** before replacement → compare edit vs record → inspect the concept cluster → repair only the semantic defect.
- Rules `MS-1`–`MS-7` with the issue's classifications and severities verbatim, including the MS-4 boundary note to `math-claim-integrity` and the MS-6 boundary note to `math-notation-consistency` NC-7.
- Examples cover all 8 must-flag and 6 must-not-flag validation cases from the issue, in generic vocabulary only.
- Boundary edits to the three sibling skills (JP-16/JP-17 rule text untouched; only `Do not use`/`Relationship`/cross-report prose extended):
  - `math-claim-integrity`: claim-strength stays there; edit-changed meaning/mode goes here
  - `math-notation-consistency`: bookkeeping stays there; semantic role of notation goes here
  - `wabun-math-style`: translation and source-naming events stay with JP-16/JP-17; monolingual semantic drift goes here
- `docs/skill-rationales/math-writing.md`: covered-skills list → four; new §6 with Originating failure mode / Ownership boundary / Compact live examples (`uda-lab/lean-pde-notes#51`–`#59`, full `owner/repository#number` form per the issue comment) / the 8 Protected behaviour clauses; old §6 renumbered to §7 "Relationship among the four skills" with a fourth ownership bullet.
- README: `math-semantic-preservation` appended to `skills/README.md`; new `### Mathematical writing` category in the root README. **Note:** the category also lists `math-claim-integrity`, `math-notation-consistency`, and `wabun-math-style`, which were previously missing from the root README — a one-skill category would have misrepresented the existing set. (`research-significance` / `shell-script-engineering` remain unlisted; left for a follow-up issue.)

## Validation

No CI in this repo; convention checks run locally:

- Frontmatter: exactly `name` + `description`, `name` == directory → **OK**
- Structure: 224 lines; section order matches sibling math-writing skills; all `MS-1`–`MS-7` present → **OK**
- `grep -rn 'lean-pde-notes|尾部|球内部分' skills/math-semantic-preservation/` → empty; project vocabulary confined to the rationale doc → **OK**
- Rationale doc headings: §6 inserted, §7 renumbered (`grep '^## '`) → **OK**
- Cross-references: all three siblings + both READMEs reference the new skill → **OK**

## Acceptance criteria walk (issue #153)

- [x] `skills/math-semantic-preservation/SKILL.md` exists with valid frontmatter
- [x] Semantic-anchor and semantic-record procedure defined (Procedure 1–2)
- [x] Covers referent, operation/result, domain/codomain, quantifier mode, provenance, notation role (MS-1–MS-6 + Output field enum)
- [x] Requires occurrence classification before terminology migration (Procedure 3, MS-7)
- [x] Checks concept-cluster synchronization (Procedure 5, MS-7)
- [x] Distinguishes pointwise vs a.e. and representatives vs equivalence classes (MS-3, MS-4 + examples)
- [x] Distinguishes argument numbering from tensor-factor/coordinate numbering (MS-1, MS-5, MS-6 + examples)
- [x] Explicit non-overlapping boundaries with the three math-writing skills (Do not use + sibling edits + rationale §6/§7)
- [x] Must-flag / must-not-flag cases cover the principal live-example classes (8 + 6)
- [x] Project-specific vocabulary only in the rationale doc and issue history
- [x] No initial script added

🤖 Generated with [Claude Code](https://claude.com/claude-code)