### PR TITLE
README: list research-significance and shell-script-engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Each skill must live at `skills/<skill-name>/SKILL.md`.
 - `math-semantic-preservation`: review or rewrite mathematical prose so edits, paraphrases, and terminology migrations preserve the exact source meaning — referent identity, operation vs result, quantifier and equality mode, provenance, and notation role
 - `wabun-math-style`: detect and correct Japanese-language anti-patterns in mathematical writing — epistemic hedges, tense and voice discipline, connective and particle logic, borrowed vocabulary, terminology SoT drift, and concept-preserving translation
 
+### Research review
+
+- `research-significance`: assess whether a mathematical or applied-mathematical research direction is locally significant — separating correctness, novelty, and scholarly value — before prose polishing or source-of-truth treatment
+
 ### Repository guidance
 
 - `growing-agents-md`: seed, lint, or update a compact canonical `AGENTS.md` with deterministic guardrails
@@ -87,6 +91,10 @@ Each skill must live at `skills/<skill-name>/SKILL.md`.
 ### Dev containers
 
 - `devcontainer-cli`: review, validate, and troubleshoot Dev Container setup with explicit CLI-first guidance
+
+### Shell scripting
+
+- `shell-script-engineering`: create, edit, or review non-trivial Bash/sh where correctness depends on execution context, permissions, filesystem mutation, argument parsing, idempotency, or CI/container behaviour
 
 ### Delivery workflow
 


### PR DESCRIPTION
Closes #156

## Summary

Adds the two skills missing from the root README "Current skills" catalogue, each condensed from its frontmatter description:

- `research-significance` under a new `### Research review` category
- `shell-script-engineering` under a new `### Shell scripting` category

No changes to the skills themselves or to `skills/README.md` (already complete).

## Validation

- Catalogue completeness check: every directory under `skills/` (28) now appears as a `- `skill`:` entry in the root README; script comparing `skills/*` dirs against README entries reports `missing: none` → **OK**

## Acceptance criteria walk (issue #156)

- [x] Root `README.md` lists `research-significance` with a one-line description under a fitting category
- [x] Root `README.md` lists `shell-script-engineering` with a one-line description under a fitting category
- [x] Every directory under `skills/` appears in the root README catalogue

## Merge authorization

Per user instruction: reviewer = auggie only; merge-gate pass pre-approved — merge immediately after the auggie review is addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)